### PR TITLE
Rlog specify logfields from context

### DIFF
--- a/pkg/rlog/log.go
+++ b/pkg/rlog/log.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/NorskHelsenett/ror/pkg/rlog"
 	"github.com/spf13/viper"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -210,6 +211,7 @@ func correlateWithTrace(ctx context.Context, msg string, lvl zapcore.Level, fiel
 // tries to get a predifined set of fields from context, if the field is not
 // present int the context it is ignored
 func getFieldsFromContext(ctx context.Context, fields *[]Field) {
+	Info("looking for fields in context", rlog.Any("fields", l.ContextKeyFields))
 	for _, key := range l.ContextKeyFields {
 		Info("found field", Any("key", key))
 		if ctx.Value(key) != nil {

--- a/pkg/rlog/log.go
+++ b/pkg/rlog/log.go
@@ -112,7 +112,6 @@ func Fatal(msg string, err error, fields ...Field) {
 func Infoc(ctx context.Context, msg string, fields ...Field) {
 	correlateWithTrace(ctx, msg, zap.InfoLevel, &fields)
 	getFieldsFromContext(ctx, &fields)
-	Info("debuging fields from context", Any("fields", fields))
 	l.Info(msg, fields...)
 }
 
@@ -211,10 +210,8 @@ func correlateWithTrace(ctx context.Context, msg string, lvl zapcore.Level, fiel
 // tries to get a predifined set of fields from context, if the field is not
 // present int the context it is ignored
 func getFieldsFromContext(ctx context.Context, fields *[]Field) {
-	Info("looking for fields in context", Any("fields", l.ContextKeyFields))
 	for _, key := range l.ContextKeyFields {
 		if ctx.Value(key) != nil {
-			Info("found field", Any("key", key))
 			*fields = append(*fields, zap.Any(key, ctx.Value(key)))
 		}
 	}

--- a/pkg/rlog/log.go
+++ b/pkg/rlog/log.go
@@ -33,6 +33,7 @@ var (
 
 type Logger struct {
 	*zap.Logger
+	ContextKeyFields []string
 }
 
 func init() {
@@ -50,8 +51,23 @@ func InitializeRlog() {
 		panic(fmt.Errorf("unable to initialize logger: %w", err))
 	}
 
-	l = Logger{zapLogger}
+	l = Logger{
+		Logger:           zapLogger,
+		ContextKeyFields: []string{},
+	}
+
 	Debug("global logger initialized", String("level", logLevel.String()))
+}
+
+// AddContextKeyField adds a key to look for in a contexts so that we
+// can add the context value as a persistent field to all logs
+func AddContextKeyField(key string) error {
+	if key == "" {
+		return fmt.Errorf("empty key")
+	}
+
+	l.ContextKeyFields = append(l.ContextKeyFields, key)
+	return nil
 }
 
 // Info logs a message at InfoLevel. The message includes any fields passed
@@ -194,8 +210,11 @@ func correlateWithTrace(ctx context.Context, msg string, lvl zapcore.Level, fiel
 // tries to get a predifined set of fields from context, if the field is not
 // present int the context it is ignored
 func getFieldsFromContext(ctx context.Context, fields *[]Field) {
-	if reqId, ok := ctx.Value(RequestIdKey).(string); ok {
-		*fields = append(*fields, zap.String("requestId", reqId))
+	for _, key := range l.ContextKeyFields {
+		Info("found field", Any("key", key))
+		if ctx.Value(key) != nil {
+			*fields = append(*fields, zap.Any(key, ctx.Value(key)))
+		}
 	}
 }
 

--- a/pkg/rlog/log.go
+++ b/pkg/rlog/log.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/NorskHelsenett/ror/pkg/rlog"
 	"github.com/spf13/viper"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -211,7 +210,7 @@ func correlateWithTrace(ctx context.Context, msg string, lvl zapcore.Level, fiel
 // tries to get a predifined set of fields from context, if the field is not
 // present int the context it is ignored
 func getFieldsFromContext(ctx context.Context, fields *[]Field) {
-	Info("looking for fields in context", rlog.Any("fields", l.ContextKeyFields))
+	Info("looking for fields in context", Any("fields", l.ContextKeyFields))
 	for _, key := range l.ContextKeyFields {
 		Info("found field", Any("key", key))
 		if ctx.Value(key) != nil {

--- a/pkg/rlog/log.go
+++ b/pkg/rlog/log.go
@@ -112,6 +112,7 @@ func Fatal(msg string, err error, fields ...Field) {
 func Infoc(ctx context.Context, msg string, fields ...Field) {
 	correlateWithTrace(ctx, msg, zap.InfoLevel, &fields)
 	getFieldsFromContext(ctx, &fields)
+	Info("debuging fields from context", Any("fields", fields))
 	l.Info(msg, fields...)
 }
 
@@ -212,8 +213,8 @@ func correlateWithTrace(ctx context.Context, msg string, lvl zapcore.Level, fiel
 func getFieldsFromContext(ctx context.Context, fields *[]Field) {
 	Info("looking for fields in context", Any("fields", l.ContextKeyFields))
 	for _, key := range l.ContextKeyFields {
-		Info("found field", Any("key", key))
 		if ctx.Value(key) != nil {
+			Info("found field", Any("key", key))
 			*fields = append(*fields, zap.Any(key, ctx.Value(key)))
 		}
 	}


### PR DESCRIPTION
Add function to declare what keys rlog should automatically look for in the context passed to
the context aware log funcitons (Infoc, Debugc)

this makes it possible to specify any key to look for, before you had to spcify it in rlog itself which was impossible when importing the package into other projects.