### PR TITLE
Fixing ResourceNodeStatusCapacity json property name

### DIFF
--- a/pkg/rorresources/rortypes/resourcedef_node.go
+++ b/pkg/rorresources/rortypes/resourcedef_node.go
@@ -35,7 +35,7 @@ type ResourceNodeStatusAddresses struct {
 }
 type ResourceNodeStatusCapacity struct {
 	Cpu              string `json:"cpu"`
-	EphemeralStorage string `json:"ephemeral-storage"`
+	EphemeralStorage string `json:"ephemeralStorage"`
 	Memory           string `json:"memory"`
 	Pods             string `json:"pods"`
 }


### PR DESCRIPTION
Fixing ResourceNodeStatusCapacity json property name, without hyphen