### PR TITLE
r.sh should warn when docker-compose is missing

### DIFF
--- a/r.sh
+++ b/r.sh
@@ -38,4 +38,9 @@ if ! test -f "$envfile"; then
   exit 1
 fi
 
+if ! which docker-compose 1>&2 2>/dev/null; then
+  echo "docker-compose must be installed, exiting ..."
+  exit 1
+fi
+
 docker compose --env-file $envfile up openldap dex init-dex-db vault mongodb rabbitmq mongo-express redis ms-auth ms-kind ms-talos $services


### PR DESCRIPTION
Why:

* The `docker-compose` command is required to run `r.sh`, because it calls `docker compose`, which uses the `docker-compose` command.
* The error when `docker-compose` is missing is unintelligible:
  ``` 
  $ docker compose --env-file ...
  unknown flag: --env-file
  See 'docker --help'.
  ...
  ```

This change addresses the need by:

* Checking for the presence of `docker-compose` and informing the user to install it.


-----------------

Tested on Manjaro Linux. I don't know if `docker`/`docker-compose` is packaged differently on MacOS, so this should be tested there.