### PR TITLE
feat: Added new resourceclient to ror client.

### DIFF
--- a/cmd/agentv2/services/resourceupdatev2/hashlist.go
+++ b/cmd/agentv2/services/resourceupdatev2/hashlist.go
@@ -2,6 +2,7 @@ package resourceupdatev2
 
 import (
 	"fmt"
+
 	"github.com/NorskHelsenett/ror/cmd/agentv2/clients"
 	"github.com/NorskHelsenett/ror/cmd/agentv2/services/authservice"
 
@@ -39,14 +40,13 @@ func InitHashList() (*apicontractsv2resources.HashList, error) {
 
 }
 func InitHashListv2() (*apicontractsv2resources.HashList, error) {
-	var hashList apicontractsv2resources.HashList
 	rorclient := clients.RorConfig.GetRorClient()
 	hashList, err := rorclient.ResourceV2().GetOwnHashes()
 	if err != nil {
 		fmt.Println("Error getting hashlist from api", err)
 		return nil, err
 	}
-	return &hashList, nil
+	return hashList, nil
 
 }
 

--- a/cmd/agentv2/services/resourceupdatev2/resourcecache.go
+++ b/cmd/agentv2/services/resourceupdatev2/resourcecache.go
@@ -1,10 +1,12 @@
 package resourceupdatev2
 
 import (
+	"context"
 	"fmt"
+	"time"
+
 	"github.com/NorskHelsenett/ror/cmd/agentv2/clients"
 	"github.com/NorskHelsenett/ror/cmd/agentv2/services/authservice"
-	"time"
 
 	"github.com/NorskHelsenett/ror/pkg/apicontracts/apiresourcecontracts"
 	"github.com/NorskHelsenett/ror/pkg/apicontracts/v2/apicontractsv2resources"
@@ -104,7 +106,7 @@ func (rc *resourcecache) RunWorkQeue() {
 	}
 	cacheworkqueue := rc.WorkQueue.ConsumeWorkQeue()
 	rorclient := clients.RorConfig.GetRorClient()
-	status, err := rorclient.ResourceV2().Update(cacheworkqueue.ResourceSet)
+	status, err := rorclient.ResourceV2().Update(context.Background(), *cacheworkqueue.ResourceSet)
 	if err != nil {
 		rlog.Error("error sending resources update to ror, added to retryQeue", err)
 		rc.WorkQueue.reQueue(cacheworkqueue)

--- a/cmd/api/controllers/v2/resourcescontroller/resources_controller.go
+++ b/cmd/api/controllers/v2/resourcescontroller/resources_controller.go
@@ -53,7 +53,16 @@ func ExistsResources() gin.HandlerFunc {
 		ctx, cancel := gincontext.GetRorContextFromGinContext(c)
 		defer cancel()
 
+		if c.Param("uid") == "" {
+			c.JSON(http.StatusBadRequest, "empty uid")
+			return
+		}
+
 		resources := resourcesv2service.GetResourceByUID(ctx, c.Param("uid"))
+		if resources == nil {
+			c.Status(http.StatusNotFound)
+			return
+		}
 
 		// Validate that the correct uid is provided
 		if len(resources.Resources) != 1 {
@@ -78,12 +87,7 @@ func ExistsResources() gin.HandlerFunc {
 			return
 		}
 
-		if c.Param("uid") == "" {
-			c.JSON(http.StatusBadRequest, "empty uid")
-			return
-		}
-
-		if resourcesservice.CheckResourceExist(ctx, c.Param("uid")) {
+		if resources.Len() == 1 {
 			c.Status(http.StatusNoContent)
 			return
 		} else {

--- a/cmd/api/routes/route_setup.go
+++ b/cmd/api/routes/route_setup.go
@@ -1,6 +1,8 @@
 package routes
 
 import (
+	"time"
+
 	"github.com/NorskHelsenett/ror/cmd/api/auth"
 	ctrlAcl "github.com/NorskHelsenett/ror/cmd/api/controllers/acl"
 	ctrlApikeys "github.com/NorskHelsenett/ror/cmd/api/controllers/apikeys"
@@ -25,7 +27,6 @@ import (
 	ctrlUsers "github.com/NorskHelsenett/ror/cmd/api/controllers/users"
 	v2resourcescontroller "github.com/NorskHelsenett/ror/cmd/api/controllers/v2/resourcescontroller"
 	ctrlWorkspaces "github.com/NorskHelsenett/ror/cmd/api/controllers/workspaces"
-	"time"
 
 	"github.com/NorskHelsenett/ror/cmd/api/controllers/v2/handlerv2self"
 	"github.com/NorskHelsenett/ror/cmd/api/webserver/middlewares"
@@ -330,9 +331,11 @@ func SetupRoutes(router *gin.Engine) {
 
 	resourceRoute.GET("", v2resourcescontroller.GetResources())
 	resourceRoute.POST("", v2resourcescontroller.NewResource())
-	resourceRoute.GET("/uid/:uid", v2resourcescontroller.GetResource())
-	resourceRoute.PUT("/uid/:uid", v2resourcescontroller.UpdateResource())
 	resourceRoute.DELETE("/uid/:uid", v2resourcescontroller.DeleteResource())
 	resourceRoute.HEAD("/uid/:uid", v2resourcescontroller.ExistsResources())
 	resourceRoute.GET("/hashes", v2resourcescontroller.GetResourceHashList())
+
+	//deprecated: let client deal with special cases
+	resourceRoute.GET("/uid/:uid", v2resourcescontroller.GetResource())
+	resourceRoute.PUT("/uid/:uid", v2resourcescontroller.UpdateResource())
 }

--- a/pkg/clients/rorclient/client.go
+++ b/pkg/clients/rorclient/client.go
@@ -10,7 +10,6 @@ import (
 	v1resources "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v1/resources"
 	v1stream "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v1/stream"
 	v1workspaces "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v1/workspaces"
-	v2resources "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/resources"
 	"github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/rorclientv2self"
 )
 
@@ -29,7 +28,7 @@ type RorClient struct {
 	projectsClientV1   v1projects.ProjectsInterface
 	resourceClientV1   v1resources.ResourceInterface
 	metricsClientV1    v1metrics.MetricsInterface
-	resourcesClientV2  v2resources.ResourcesInterface
+	resourcesClientV2  ResourceClient
 }
 
 func NewRorClient(transport transports.RorTransport) *RorClient {
@@ -44,7 +43,7 @@ func NewRorClient(transport transports.RorTransport) *RorClient {
 		selfClientV2:       transport.Self(),
 		resourceClientV1:   transport.Resources(),
 		metricsClientV1:    transport.Metrics(),
-		resourcesClientV2:  transport.ResourcesV2(),
+		resourcesClientV2:  NewResourceClient(transport.ResourcesV2()),
 	}
 }
 
@@ -85,6 +84,6 @@ func (c *RorClient) Ping() error {
 	return c.Transport.Ping()
 }
 
-func (c *RorClient) ResourceV2() v2resources.ResourcesInterface {
-	return c.resourcesClientV2
+func (c *RorClient) ResourceV2() *ResourceClient {
+	return &c.resourcesClientV2
 }

--- a/pkg/clients/rorclient/resources.go
+++ b/pkg/clients/rorclient/resources.go
@@ -3,6 +3,7 @@ package rorclient
 import (
 	"context"
 
+	"github.com/NorskHelsenett/ror/pkg/apicontracts/v2/apicontractsv2resources"
 	v2resources "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/resources"
 	"github.com/NorskHelsenett/ror/pkg/rorresources"
 )
@@ -76,4 +77,13 @@ func (r *ResourceClient) Exists(ctx context.Context, uid string) (bool, error) {
 	}
 
 	return res, nil
+}
+
+func (r *ResourceClient) GetOwnHashes() (*apicontractsv2resources.HashList, error) {
+	res, err := r.Transport.GetOwnHashes()
+	if err != nil {
+		return nil, err
+	}
+
+	return &res, nil
 }

--- a/pkg/clients/rorclient/resources.go
+++ b/pkg/clients/rorclient/resources.go
@@ -1,0 +1,79 @@
+package rorclient
+
+import (
+	"context"
+
+	v2resources "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/resources"
+	"github.com/NorskHelsenett/ror/pkg/rorresources"
+)
+
+type ResourceClient struct {
+	Transport v2resources.ResourcesInterface
+}
+
+func NewResourceClient(transport v2resources.ResourcesInterface) ResourceClient {
+	client := ResourceClient{
+		Transport: transport,
+	}
+
+	return client
+}
+
+func (r *ResourceClient) Get(ctx context.Context, query rorresources.ResourceQuery) (*rorresources.ResourceSet, error) {
+	set, err := r.Transport.Get(query)
+	if err != nil {
+		return nil, err
+	}
+
+	return &set, nil
+}
+
+func (r *ResourceClient) GetByUid(ctx context.Context, uid string) (*rorresources.ResourceSet, error) {
+	query := rorresources.NewResourceQuery().WithUID(uid)
+
+	set, err := r.Get(ctx, *query)
+	if err != nil {
+		return nil, err
+	}
+
+	return set, nil
+}
+
+func (r *ResourceClient) Update(ctx context.Context, set rorresources.ResourceSet) (*rorresources.ResourceUpdateResults, error) {
+	res, err := r.Transport.Update(&set)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func (r *ResourceClient) UpdateOne(ctx context.Context, resource rorresources.Resource) (*rorresources.ResourceUpdateResults, error) {
+	set := rorresources.NewResourceSet()
+	set.Add(&resource)
+
+	res, err := r.Update(ctx, *set)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func (r *ResourceClient) Delete(ctx context.Context, uid string) (*rorresources.ResourceUpdateResults, error) {
+	res, err := r.Transport.Delete(uid)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func (r *ResourceClient) Exists(ctx context.Context, uid string) (bool, error) {
+	res, err := r.Transport.Exists(uid)
+	if err != nil {
+		return false, err
+	}
+
+	return res, nil
+}

--- a/pkg/clients/rorclient/transports/resttransport/httpclient/client.go
+++ b/pkg/clients/rorclient/transports/resttransport/httpclient/client.go
@@ -123,6 +123,29 @@ func (t *HttpTransportClient) PutJSON(path string, in any, out any, params ...Ht
 	return nil
 }
 
+func (t *HttpTransportClient) Delete(path string, out any, params ...HttpTransportClientParams) error {
+	req, err := http.NewRequest("DELETE", t.Config.BaseURL+path, nil)
+	if err != nil {
+		return err
+	}
+
+	t.AddCommonHeaders(req)
+	t.ParseParams(req, params...)
+
+	res, err := t.Client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	err = handleResponse(res, out)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func handleResponse(res *http.Response, out any) error {
 
 	if res.StatusCode > 399 || res.StatusCode < 200 {

--- a/pkg/clients/rorclient/transports/resttransport/httpclient/client.go
+++ b/pkg/clients/rorclient/transports/resttransport/httpclient/client.go
@@ -146,6 +146,26 @@ func (t *HttpTransportClient) Delete(path string, out any, params ...HttpTranspo
 	return nil
 }
 
+// Head makes a HEAD request with the given path and params.
+// It returns only the header and status code from the result, as it expects no body in return.
+func (t *HttpTransportClient) Head(path string, params ...HttpTransportClientParams) (http.Header, int, error) {
+	req, err := http.NewRequest("HEAD", t.Config.BaseURL+path, nil)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	t.AddCommonHeaders(req)
+	t.ParseParams(req, params...)
+
+	res, err := t.Client.Do(req)
+	if err != nil {
+		return nil, -1, err
+	}
+	defer res.Body.Close()
+
+	return res.Header, res.StatusCode, nil
+}
+
 func handleResponse(res *http.Response, out any) error {
 
 	if res.StatusCode > 399 || res.StatusCode < 200 {

--- a/pkg/clients/rorclient/transports/resttransport/v2/resources/resources.go
+++ b/pkg/clients/rorclient/transports/resttransport/v2/resources/resources.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/NorskHelsenett/ror/pkg/apicontracts/v2/apicontractsv2resources"
@@ -62,18 +63,21 @@ func (c *V2Client) Delete(uid string) (*rorresources.ResourceUpdateResults, erro
 }
 
 func (c *V2Client) Exists(uid string) (bool, error) {
-	//url, err := url.JoinPath(c.basePath, "uid", uid)
-	//if err != nil {
-	//	return nil, fmt.Errorf("could not create url: %w", err)
-	//}
+	url, err := url.JoinPath(c.basePath, "uid", uid)
+	if err != nil {
+		return false, fmt.Errorf("could not create url: %w", err)
+	}
 
-	// we need ta add a head request to client
-	//err = c.Client.(url, &out)
-	//if err != nil {
-	//	return nil, err
-	//}
+	_, status, err := c.Client.Head(url)
+	if err != nil {
+		return false, err
+	}
 
-	return false, fmt.Errorf("not implemented")
+	if status == http.StatusNoContent {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 func (c *V2Client) GetOwnHashes() (apicontractsv2resources.HashList, error) {

--- a/pkg/clients/rorclient/transports/resttransport/v2/resources/resources.go
+++ b/pkg/clients/rorclient/transports/resttransport/v2/resources/resources.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"net/url"
 
 	"github.com/NorskHelsenett/ror/pkg/apicontracts/v2/apicontractsv2resources"
 	"github.com/NorskHelsenett/ror/pkg/clients/rorclient/transports/resttransport/httpclient"
@@ -23,7 +25,6 @@ func NewV2Client(client *httpclient.HttpTransportClient) *V2Client {
 }
 
 func (c *V2Client) Get(query rorresources.ResourceQuery) (rorresources.ResourceSet, error) {
-	// implementation goes here
 	var res rorresources.ResourceSet
 	jsonQuery, err := json.Marshal(&query)
 	if err != nil {
@@ -44,24 +45,35 @@ func (c *V2Client) Update(res *rorresources.ResourceSet) (*rorresources.Resource
 	return ret, nil
 }
 
-func (c *V2Client) GetByUid(uid string) (rorresources.ResourceSet, error) {
-	// implementation goes here
-	return rorresources.ResourceSet{}, nil
+func (c *V2Client) Delete(uid string) (*rorresources.ResourceUpdateResults, error) {
+	var out rorresources.ResourceUpdateResults
+
+	url, err := url.JoinPath(c.basePath, "uid", uid)
+	if err != nil {
+		return nil, fmt.Errorf("could not create url: %w", err)
+	}
+
+	err = c.Client.Delete(url, &out)
+	if err != nil {
+		return nil, err
+	}
+
+	return &out, nil
 }
 
-func (c *V2Client) UpdateByUid(uid string, res *rorresources.ResourceSet) (string, error) {
-	// implementation goes here
-	return "", nil
-}
+func (c *V2Client) Exists(uid string) (bool, error) {
+	//url, err := url.JoinPath(c.basePath, "uid", uid)
+	//if err != nil {
+	//	return nil, fmt.Errorf("could not create url: %w", err)
+	//}
 
-func (c *V2Client) DeleteByUid(uid string) (string, error) {
-	// implementation goes here
-	return "", nil
-}
+	// we need ta add a head request to client
+	//err = c.Client.(url, &out)
+	//if err != nil {
+	//	return nil, err
+	//}
 
-func (c *V2Client) ExistsByUid(uid string) (bool, error) {
-	// implementation goes here
-	return false, nil
+	return false, fmt.Errorf("not implemented")
 }
 
 func (c *V2Client) GetOwnHashes() (apicontractsv2resources.HashList, error) {

--- a/pkg/clients/rorclient/v2/resources/resources.go
+++ b/pkg/clients/rorclient/v2/resources/resources.go
@@ -8,9 +8,7 @@ import (
 type ResourcesInterface interface {
 	Get(query rorresources.ResourceQuery) (rorresources.ResourceSet, error)
 	Update(res *rorresources.ResourceSet) (*rorresources.ResourceUpdateResults, error)
-	GetByUid(uid string) (rorresources.ResourceSet, error)
-	UpdateByUid(uid string, res *rorresources.ResourceSet) (string, error)
-	DeleteByUid(uid string) (string, error)
-	ExistsByUid(uid string) (bool, error)
+	Delete(uid string) (*rorresources.ResourceUpdateResults, error)
+	Exists(uid string) (bool, error)
 	GetOwnHashes() (apicontractsv2resources.HashList, error)
 }

--- a/pkg/rorresources/resourceset.go
+++ b/pkg/rorresources/resourceset.go
@@ -16,30 +16,11 @@ type ResourceSet struct {
 	Resources  []*Resource `json:"resources,omitempty"`
 }
 
-type ResourceUpdateResults struct {
-	Results map[string]ResourceUpdateResult `json:"results,omitempty"`
-}
-type ResourceUpdateResult struct {
-	Status  int    `json:"status,omitempty"`
-	Message string `json:"message,omitempty"`
-}
-
 func (rs *ResourceSet) SetQuery(query *ResourceQuery) {
 	rs.query = query
 }
 func (rs *ResourceSet) GetQuery() *ResourceQuery {
 	return rs.query
-}
-
-// FailedResources is a method to return a list of failed resources.
-func (r *ResourceUpdateResults) GetFailedResources() map[string]ResourceUpdateResult {
-	failedResources := make(map[string]ResourceUpdateResult, 0)
-	for key, value := range r.Results {
-		if value.Status > 399 || value.Status < 200 {
-			failedResources[key] = value
-		}
-	}
-	return failedResources
 }
 
 func NewResourceSet() *ResourceSet {
@@ -185,4 +166,24 @@ func (r *ResourceSet) FilterByOwnerReference(ownerRef rortypes.RorResourceOwnerR
 		}
 	}
 	return &response
+}
+
+type ResourceUpdateResult struct {
+	Status  int    `json:"status,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+type ResourceUpdateResults struct {
+	Results map[string]ResourceUpdateResult `json:"results,omitempty"`
+}
+
+// FailedResources is a method to return a list of failed resources.
+func (r *ResourceUpdateResults) GetFailedResources() map[string]ResourceUpdateResult {
+	failedResources := make(map[string]ResourceUpdateResult, 0)
+	for key, value := range r.Results {
+		if value.Status > 399 || value.Status < 200 {
+			failedResources[key] = value
+		}
+	}
+	return failedResources
 }


### PR DESCRIPTION
The PR does mainly two things: implement Delete for v2 resources and adding a bit of abstraction to the ror client through the resource client. The new client aims to allow convenience methods to be built on top of the basic CRUD operaions provided by the transports.

# ROR API: 

## Resource controller
- added inn some validation from similar controller.
- It was using the old ACL framework
- changed ACL scope to read, was update. The user is doing a read
## Resource controller Delete
- changed mismatched guid error to 400, was 501, This is an error on the users part and should be reflected in the answer.
- return resource update result, was returning string. Lets us better inform the client what was deleted
## Routes
- Deprecate update by uid and get by uid, get and update can already do this, so we can let the client take care of convenience methods like this.

# ROR client

## ROR client
* rorclient no longer has a reference to the resource transport, instead it exposes the new resource client.
## Resource client
![1729798692-24 10-shareX-screen](https://github.com/user-attachments/assets/46de816e-6b57-4f31-9566-dc396bdf7016)
* abstraction layers for the resource transport, implements CRUD and a few convenience methods built on top of the basic operations. The deprecated api routes get by uid and update by uid (now called update one) is implemented here.
## Resttransport http client
* Add delete method
## Resttransport resources
* removed update by uid, get by uid
* implemented delete
* exists still needs to be implemented
## v2 Resources interface
* removed update by uid and get by uid from the interface, transports should only implement basic CRUD
* renamed delete by uid to delete and exists by uid to exists. 
## Resource set
* refactored to keep struct and methods together. 
 Added new resource client
