### PR TITLE
fix: k8s agent trying to get VMs from kubernetes

### DIFF
--- a/cmd/agent/clients/dynamicclient_generated.go
+++ b/cmd/agent/clients/dynamicclient_generated.go
@@ -28,7 +28,6 @@ func InitSchema() []schema.GroupVersionResource {
 	schemas = append(schemas, schema.GroupVersionResource{Group: "aquasecurity.github.io", Version: "v1alpha1", Resource: "configauditreports"})
 	schemas = append(schemas, schema.GroupVersionResource{Group: "aquasecurity.github.io", Version: "v1alpha1", Resource: "rbacassessmentreports"})
 	schemas = append(schemas, schema.GroupVersionResource{Group: "aquasecurity.github.io", Version: "v1alpha1", Resource: "clustercompliancereports"})
-	schemas = append(schemas, schema.GroupVersionResource{Group: "general.ror.internal", Version: "v1alpha1", Resource: "Vms"})
 
 	return schemas
 }

--- a/cmd/agentv2/clients/dynamicclient/dynamicclient_generated.go
+++ b/cmd/agentv2/clients/dynamicclient/dynamicclient_generated.go
@@ -28,7 +28,6 @@ func InitSchema() []schema.GroupVersionResource {
 	schemas = append(schemas, schema.GroupVersionResource{Group: "aquasecurity.github.io", Version: "v1alpha1", Resource: "configauditreports"})
 	schemas = append(schemas, schema.GroupVersionResource{Group: "aquasecurity.github.io", Version: "v1alpha1", Resource: "rbacassessmentreports"})
 	schemas = append(schemas, schema.GroupVersionResource{Group: "aquasecurity.github.io", Version: "v1alpha1", Resource: "clustercompliancereports"})
-	schemas = append(schemas, schema.GroupVersionResource{Group: "general.ror.internal", Version: "v1alpha1", Resource: "Vms"})
 
 	return schemas
 }

--- a/pkg/rorresources/rordefs/defs.go
+++ b/pkg/rorresources/rordefs/defs.go
@@ -13,6 +13,7 @@ type ApiResourceType string
 const (
 	ApiResourceTypeUnknown    ApiResourceType = ""
 	ApiResourceTypeAgent      ApiResourceType = "Agent"
+	ApiResourceTypeVmAgent    ApiResourceType = "VmAgent"
 	ApiResourceTypeTanzuAgent ApiResourceType = "TanzuAgent"
 	ApiResourceTypeInternal   ApiResourceType = "Internal"
 )
@@ -326,6 +327,6 @@ var Resourcedefs = []ApiResource{
 		},
 		Plural:     "Vms",
 		Namespaced: false,
-		Types:      []ApiResourceType{ApiResourceTypeAgent},
+		Types:      []ApiResourceType{ApiResourceTypeVmAgent},
 	},
 }


### PR DESCRIPTION
When generating the schema for the k8s agent, the generator gets all resources with type rorResourceAgent. I've added a new resource type ResourceTypeVMAgent, updated the VM resource, and re run the generator.