### PR TITLE
feature/add platform to docker compose to support ror-web on apple silicon

### DIFF
--- a/hacks/docker-compose/web.yaml
+++ b/hacks/docker-compose/web.yaml
@@ -8,6 +8,7 @@ services:
         API_PORT: 10000
     ports:
       - "11000:8090"
+    platform: linux/amd64
     volumes:
       - type: bind
         source: ../../web/admin/nginx/http_compose.conf


### PR DESCRIPTION
As we dont do multibuild at the moment platform has to be set to linux\amd64