### PR TITLE
refactor: usage should be a number not a string

### DIFF
--- a/pkg/rorresources/rortypes/resourcedef_vm.go
+++ b/pkg/rorresources/rortypes/resourcedef_vm.go
@@ -43,7 +43,7 @@ type ResourceVirtualMachineDiskSpec struct {
 }
 
 type ResourceVirtualMachineDiskStatus struct {
-	UsageBytes string `json:"usageBytes"`
+	UsageBytes int `json:"usageBytes"`
 
 	// is this disk mounted by the os? A disk might be attached to the vm but
 	// not mounted by the OS, it can also be unknown because the vm might not report


### PR DESCRIPTION
Using a string for usage created some issues when adding usage from diferent os partitions together, changed it to an int which makes sense anyways.