### PR TITLE
feat(vm): add os-family to model

### DIFF
--- a/pkg/rorresources/rortypes/resourcedef_vm.go
+++ b/pkg/rorresources/rortypes/resourcedef_vm.go
@@ -67,6 +67,7 @@ type ResourceVirtualMachineNetworkStatus struct {
 type ResourceVirtualMachineOperatingSystemStatus struct {
 	Id           string `json:"id"`
 	Name         string `json:"name"`
+	Family       string `json:"family"`
 	Version      string `json:"version"`
 	HostName     string `json:"hostName"`
 	PowerState   string `json:"powerState"`


### PR DESCRIPTION
Added to make it easier to determine if an unknown os-name is a linux flavour, or other os