### PR TITLE
fix(vm): remove json tags from embedded structs in vm model

### DIFF
--- a/pkg/rorresources/rortypes/resourcedef_vm.go
+++ b/pkg/rorresources/rortypes/resourcedef_vm.go
@@ -52,7 +52,7 @@ type ResourceVirtualMachineDiskStatus struct {
 	// it is actually not mounted.
 	IsMounted bool `json:"isMounted"`
 
-	ResourceVirtualMachineDiskSpec `json:"spec"`
+	ResourceVirtualMachineDiskSpec
 }
 
 type ResourceVirtualMachineNetworkStatus struct {
@@ -81,9 +81,9 @@ type ResourceVirtualMachineCpuSpec struct {
 }
 
 type ResourceVirtualMachineCpuStatus struct {
-	Unit                          string `json:"unit"` //describes what unit the usage is given in
-	Usage                         int    `json:"usage"`
-	ResourceVirtualMachineCpuSpec `json:"spec"`
+	Unit  string `json:"unit"` //describes what unit the usage is given in
+	Usage int    `json:"usage"`
+	ResourceVirtualMachineCpuSpec
 }
 
 type ResourceVirtualMachineMemorySpec struct {
@@ -91,9 +91,9 @@ type ResourceVirtualMachineMemorySpec struct {
 }
 
 type ResourceVirtualMachineMemoryStatus struct {
-	Unit                             string `json:"unit"` //describes what unit the usage is given in
-	Usage                            int    `json:"usage"`
-	ResourceVirtualMachineMemorySpec `json:"spec"`
+	Unit  string `json:"unit"` //describes what unit the usage is given in
+	Usage int    `json:"usage"`
+	ResourceVirtualMachineMemorySpec
 }
 
 type ResourceVirtualMachineTag struct {


### PR DESCRIPTION
When running the generator it would not consider the json tags and would create a flat structure without a surrounding spec objec in the typescript model. However the json structure would have this spec object. To make sure all the models are alligned we remove the json tags from all embedded objects.