### PR TITLE
feat(rorclient): add support for acl operations against the ror api

### DIFF
--- a/pkg/clients/rorclient/acl.go
+++ b/pkg/clients/rorclient/acl.go
@@ -1,0 +1,33 @@
+package rorclient
+
+import (
+	"context"
+
+	"github.com/NorskHelsenett/ror/pkg/apicontracts"
+	"github.com/NorskHelsenett/ror/pkg/clients/rorclient/v1/acl"
+	"github.com/NorskHelsenett/ror/pkg/models/aclmodels"
+)
+
+type AclClient struct {
+	Transport acl.AclInterface
+}
+
+func NewAclClient(transport acl.AclInterface) AclClient {
+	return AclClient{Transport: transport}
+}
+
+func (c *AclClient) Create(ctx context.Context, item aclmodels.AclV2ListItem) error {
+	return c.Transport.Create(ctx, item)
+}
+
+func (c *AclClient) Delete(ctx context.Context, id string) error {
+	return c.Transport.Delete(ctx, id)
+}
+
+func (c *AclClient) GetById(ctx context.Context, id string) (*aclmodels.AclV2ListItem, error) {
+	return c.Transport.GetById(ctx, id)
+}
+
+func (c *AclClient) GetByFilter(ctx context.Context, filter apicontracts.Filter) (*apicontracts.PaginatedResult[aclmodels.AclV2ListItem], error) {
+	return c.Transport.GetByFilter(ctx, filter)
+}

--- a/pkg/clients/rorclient/client.go
+++ b/pkg/clients/rorclient/client.go
@@ -31,6 +31,7 @@ type RorClient struct {
 	metricsClientV1    v1metrics.MetricsInterface
 	resourcesClientV2  ResourceClient
 	streamClientV2     v2stream.StreamInterface
+	AclClient          AclClient
 }
 
 func NewRorClient(transport transports.RorTransport) *RorClient {
@@ -47,6 +48,7 @@ func NewRorClient(transport transports.RorTransport) *RorClient {
 		metricsClientV1:    transport.Metrics(),
 		resourcesClientV2:  NewResourceClient(transport.ResourcesV2()),
 		streamClientV2:     transport.Streamv2(),
+		AclClient:          NewAclClient(transport.AclV1()),
 	}
 }
 

--- a/pkg/clients/rorclient/transports/interfaces.go
+++ b/pkg/clients/rorclient/transports/interfaces.go
@@ -1,6 +1,7 @@
 package transports
 
 import (
+	v1Acl "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v1/acl"
 	v1clusters "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v1/clusters"
 	v1datacenter "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v1/datacenter"
 	v1info "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v1/info"
@@ -26,5 +27,6 @@ type RorTransport interface {
 	Metrics() v1metrics.MetricsInterface
 	ResourcesV2() v2resources.ResourcesInterface
 	Streamv2() v2stream.StreamInterface
+	AclV1() v1Acl.AclInterface
 	Ping() error
 }

--- a/pkg/clients/rorclient/transports/resttransport/transport.go
+++ b/pkg/clients/rorclient/transports/resttransport/transport.go
@@ -7,6 +7,7 @@ import (
 	"github.com/NorskHelsenett/ror/pkg/clients/rorclient/transports/resttransport/sseclient/v1sseclient"
 	"github.com/NorskHelsenett/ror/pkg/clients/rorclient/transports/resttransport/sseclient/v2sseclient"
 
+	"github.com/NorskHelsenett/ror/pkg/clients/rorclient/transports/resttransport/v1/acl"
 	restv1clusters "github.com/NorskHelsenett/ror/pkg/clients/rorclient/transports/resttransport/v1/clusters"
 	restv1datacenter "github.com/NorskHelsenett/ror/pkg/clients/rorclient/transports/resttransport/v1/datacenter"
 	restv1info "github.com/NorskHelsenett/ror/pkg/clients/rorclient/transports/resttransport/v1/info"
@@ -18,6 +19,7 @@ import (
 	restv2resources "github.com/NorskHelsenett/ror/pkg/clients/rorclient/transports/resttransport/v2/resources"
 	"github.com/NorskHelsenett/ror/pkg/clients/rorclient/transports/resttransport/v2/restclientv2self"
 	restv2stream "github.com/NorskHelsenett/ror/pkg/clients/rorclient/transports/resttransport/v2/v2stream"
+	v1Acl "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v1/acl"
 	v1clusters "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v1/clusters"
 	v1datacenter "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v1/datacenter"
 	v1info "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v1/info"
@@ -42,6 +44,7 @@ type RorHttpTransport struct {
 	resourcesClientV1  v1resources.ResourceInterface
 	metricsClientV1    v1metrics.MetricsInterface
 	resourcesClientV2  v2resources.ResourcesInterface
+	aclClientV1        v1Acl.AclInterface
 	selfClientV2       v2self.SelfInterface
 	streamClientV2     v2stream.StreamInterface
 }
@@ -63,6 +66,7 @@ func NewRorHttpTransport(config *httpclient.HttpTransportClientConfig) *RorHttpT
 		resourcesClientV1:  restv1resources.NewV1Client(client),
 		metricsClientV1:    restv1metrics.NewV1Client(client),
 		resourcesClientV2:  restv2resources.NewV2Client(client),
+		aclClientV1:        acl.NewV1Client(client),
 		streamClientV2:     restv2stream.NewV2Client(v2sseclient.NewSSEClient(client)),
 	}
 	return t
@@ -121,6 +125,10 @@ func (t *RorHttpTransport) Resources() v1resources.ResourceInterface {
 
 func (t *RorHttpTransport) ResourcesV2() v2resources.ResourcesInterface {
 	return t.resourcesClientV2
+}
+
+func (t *RorHttpTransport) AclV1() v1Acl.AclInterface {
+	return t.aclClientV1
 }
 
 func (t *RorHttpTransport) Streamv2() v2stream.StreamInterface {

--- a/pkg/clients/rorclient/transports/resttransport/v1/acl/acl.go
+++ b/pkg/clients/rorclient/transports/resttransport/v1/acl/acl.go
@@ -1,0 +1,100 @@
+package acl
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/NorskHelsenett/ror/pkg/apicontracts"
+	"github.com/NorskHelsenett/ror/pkg/clients/rorclient/transports/resttransport/httpclient"
+	"github.com/NorskHelsenett/ror/pkg/models/aclmodels"
+)
+
+type V1Client struct {
+	Client   *httpclient.HttpTransportClient
+	BasePath string
+}
+
+func NewV1Client(client *httpclient.HttpTransportClient) *V1Client {
+	return &V1Client{
+		Client:   client,
+		BasePath: "/v1/acl",
+	}
+}
+
+func (c V1Client) GetById(ctx context.Context, id string) (*aclmodels.AclV2ListItem, error) {
+	url, err := url.Parse(c.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	url = url.JoinPath(id)
+
+	var acl aclmodels.AclV2ListItem
+
+	err = c.Client.GetJSONWithContext(ctx, url.String(), &acl)
+	if err != nil {
+		return nil, err
+	}
+
+	return &acl, nil
+}
+
+func (c V1Client) GetByFilter(ctx context.Context, filter apicontracts.Filter) (*apicontracts.PaginatedResult[aclmodels.AclV2ListItem], error) {
+	url, err := url.Parse(c.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	url = url.JoinPath("filter")
+
+	var res apicontracts.PaginatedResult[aclmodels.AclV2ListItem]
+
+	err = c.Client.PostJSONWithContext(ctx, url.String(), filter, &res)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+func (c V1Client) Create(ctx context.Context, item aclmodels.AclV2ListItem) error {
+	url, err := url.Parse(c.BasePath)
+	if err != nil {
+		return err
+	}
+
+	var res aclmodels.AclV2ListItem
+
+	err = c.Client.PostJSONWithContext(ctx, url.String(), item, &res)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c V1Client) Update(ctx context.Context, id string, item aclmodels.AclV2ListItem) error {
+
+	return nil
+}
+
+func (c V1Client) Delete(ctx context.Context, id string) error {
+	url, err := url.Parse(c.BasePath)
+	if err != nil {
+		return err
+	}
+
+	url = url.JoinPath(id)
+
+	var res bool
+	err = c.Client.DeleteWithContext(ctx, url.String(), res)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c V1Client) CheckAccess(ctx context.Context, scope, subject, access string) bool {
+	return false
+}

--- a/pkg/clients/rorclient/v1/acl/acl.go
+++ b/pkg/clients/rorclient/v1/acl/acl.go
@@ -1,0 +1,17 @@
+package acl
+
+import (
+	"context"
+
+	"github.com/NorskHelsenett/ror/pkg/apicontracts"
+	"github.com/NorskHelsenett/ror/pkg/models/aclmodels"
+)
+
+type AclInterface interface {
+	Create(ctx context.Context, item aclmodels.AclV2ListItem) error
+	Update(ctx context.Context, id string, item aclmodels.AclV2ListItem) error
+	Delete(ctx context.Context, id string) error
+	CheckAccess(ctx context.Context, scope, subject, access string) bool
+	GetById(ctx context.Context, id string) (*aclmodels.AclV2ListItem, error)
+	GetByFilter(ctx context.Context, filter apicontracts.Filter) (*apicontracts.PaginatedResult[aclmodels.AclV2ListItem], error)
+}


### PR DESCRIPTION
Adding an ACL client to the ROR client. This was done since I needed an interface to create ACLs for Virtual Machines in the Vsphere Micro Service.