### PR TITLE
fix: fixed non-wrapping errors on fmt.Errorf

### DIFF
--- a/pkg/auth/userauth/activedirectory/ad.go
+++ b/pkg/auth/userauth/activedirectory/ad.go
@@ -150,7 +150,7 @@ func (l *AdClient) search(basedn, filter string, attributes []string) (*ldap.Sea
 	)
 	result, err := l.connection.Search(request)
 	if err != nil {
-		return nil, fmt.Errorf("search error: %s", err)
+		return nil, fmt.Errorf("search error: %w", err)
 	}
 
 	if len(result.Entries) > 0 {

--- a/pkg/auth/userauth/ldaps/openldap.go
+++ b/pkg/auth/userauth/ldaps/openldap.go
@@ -115,7 +115,7 @@ func (l *LdapsClient) search(basedn, filter string, attributes []string) (*ldap.
 	)
 	result, err := l.connection.Search(request)
 	if err != nil {
-		return nil, fmt.Errorf("search error: %s", err)
+		return nil, fmt.Errorf("search error: %w", err)
 	}
 
 	if len(result.Entries) > 0 {

--- a/pkg/clients/mongodb/methods.go
+++ b/pkg/clients/mongodb/methods.go
@@ -78,7 +78,7 @@ func (rc MongodbCon) Aggregate(ctx context.Context, col string, query []bson.M, 
 
 	err = results.All(ctx, value)
 	if err != nil {
-		return fmt.Errorf("could not fetch resource: %v", err)
+		return fmt.Errorf("could not fetch resource: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
The verbs used did not wrap the errors properly, causing any checks for specific errors to fail.
Changed the formatting verbs to the correct verb - %w.