### PR TITLE
Potential fix for code scanning alert no. 42: Incorrect conversion between integer types

### DIFF
--- a/pkg/config/rorconfig/configdata.go
+++ b/pkg/config/rorconfig/configdata.go
@@ -68,7 +68,10 @@ func (cd ConfigData) Float32() float32 {
 	return float32(f)
 }
 func (cd ConfigData) Uint() uint {
-	u, _ := strconv.ParseUint(cd.Value, 10, 64)
+	u, err := strconv.ParseUint(cd.Value, 10, 64)
+	if err != nil || u > math.MaxUint {
+		return 0
+	}
 	return uint(u)
 }
 func (cd ConfigData) Uint64() uint64 {


### PR DESCRIPTION
Potential fix for [https://github.com/NorskHelsenett/ror/security/code-scanning/42](https://github.com/NorskHelsenett/ror/security/code-scanning/42)

To fix this, we should ensure that the value returned by `strconv.ParseUint` is within the valid range of `uint` on the current platform before converting it. Since `uint` is at most 64 bits, we can bound it using `math.MaxUint`, which already matches the platform’s `uint` size. This avoids truncation on 32‑bit platforms while keeping behavior unchanged for valid values.

Concretely, in `ConfigData.Uint()` in `pkg/config/rorconfig/configdata.go` (lines 70–73), we will add a check after parsing: if parsing fails or if the parsed value `u` exceeds `math.MaxUint`, we return `0` (consistent with the other methods that return zero on invalid/NaN/Inf). Otherwise, we safely cast `u` to `uint`. The file already imports `"math"` and `"strconv"`, so no new imports are required. No other methods need to change, since `Uint64` and `Uint32` either already match sizes (`Uint64`) or parse with a restricted bit size (`Uint32`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
