### PR TITLE
chore/go-fix

### DIFF
--- a/pkg/apicontracts/apicontracts.go
+++ b/pkg/apicontracts/apicontracts.go
@@ -169,9 +169,9 @@ type ClusterMetadata struct {
 }
 
 type ClusterConfig struct {
-	Versions        map[string]interface{} `json:"versions"`
-	Overrides       map[string]interface{} `json:"overrides"`
-	ProjectMetadata ProjectMetadata        `json:"projectMetadata"`
+	Versions        map[string]any  `json:"versions"`
+	Overrides       map[string]any  `json:"overrides"`
+	ProjectMetadata ProjectMetadata `json:"projectMetadata"`
 }
 
 type Versions struct {
@@ -304,25 +304,25 @@ type StatusMessage struct {
 }
 
 type ClusterControlPlaneMetadata struct {
-	ClusterId                interface{}                           `json:"clusterId"`
-	ClusterName              interface{}                           `json:"clusterName"`
-	Environment              interface{}                           `json:"environment"`
-	ProjectName              interface{}                           `json:"projectName"`
+	ClusterId                any                                   `json:"clusterId"`
+	ClusterName              any                                   `json:"clusterName"`
+	Environment              any                                   `json:"environment"`
+	ProjectName              any                                   `json:"projectName"`
 	ControlPlaneEndpoint     ClusterControlPlaneMetadataIp         `json:"controlPlaneEndpoint"`
-	ControlPlaneEndpointPort interface{}                           `json:"controlPlaneEndpointPort"`
+	ControlPlaneEndpointPort any                                   `json:"controlPlaneEndpointPort"`
 	Egress                   ClusterControlPlaneMetadataIp         `json:"egress"`
 	Datacenter               ClusterControlPlaneMetadataDatacenter `json:"datacenter"`
 }
 
 type ClusterControlPlaneMetadataDatacenter struct {
-	Name        interface{} `json:"name"`
-	Provider    interface{} `json:"provider"`
-	ApiEndpoint interface{} `json:"apiEndpoint"`
+	Name        any `json:"name"`
+	Provider    any `json:"provider"`
+	ApiEndpoint any `json:"apiEndpoint"`
 }
 
 type ClusterControlPlaneMetadataIp struct {
-	IpV4 interface{} `json:"ipv4"`
-	IpV6 interface{} `json:"ipv6"`
+	IpV4 any `json:"ipv4"`
+	IpV6 any `json:"ipv6"`
 }
 
 type Metrics struct {
@@ -447,8 +447,8 @@ type Error struct {
 }
 
 type DesiredVersion struct {
-	Key   string      `json:"key" bson:"key"`
-	Value interface{} `json:"value" bson:"value"`
+	Key   string `json:"key" bson:"key"`
+	Value any    `json:"value" bson:"value"`
 }
 
 type User struct {

--- a/pkg/apicontracts/apiresourcecontracts/resourcedef_endpoints.go
+++ b/pkg/apicontracts/apiresourcecontracts/resourcedef_endpoints.go
@@ -20,7 +20,7 @@ type ResourceEndpointSpecSubsetsAddresses struct {
 	Hostname  string                                        `json:"hostname,omitempty"`
 	Ip        string                                        `json:"ip,omitempty"`
 	NodeName  string                                        `json:"nodeName,omitempty"`
-	TargetRef ResourceEndpointSpecSubsetsAddressesTargetRef `json:"targetRef,omitempty"`
+	TargetRef ResourceEndpointSpecSubsetsAddressesTargetRef `json:"targetRef"`
 }
 
 // Deprecated: This type is only to be used in resource/v1 and will be deprecated
@@ -39,7 +39,7 @@ type ResourceEndpointSpecSubsetsNotReadyAddresses struct {
 	Hostname  string                                                `json:"hostname,omitempty"`
 	Ip        string                                                `json:"ip,omitempty"`
 	NodeName  string                                                `json:"nodeName,omitempty"`
-	TargetRef ResourceEndpointSpecSubsetsNotReadyAddressesTargetRef `json:"targetRef,omitempty"`
+	TargetRef ResourceEndpointSpecSubsetsNotReadyAddressesTargetRef `json:"targetRef"`
 }
 
 // Deprecated: This type is only to be used in resource/v1 and will be deprecated

--- a/pkg/apicontracts/apiresourcecontracts/resourcedef_ingress.go
+++ b/pkg/apicontracts/apiresourcecontracts/resourcedef_ingress.go
@@ -11,7 +11,7 @@ type ResourceIngress struct {
 
 // Deprecated: This type is only to be used in resource/v1 and will be deprecated
 type ResourceIngressSpec struct {
-	DefaultBackend   ResourceIngressSpecRulesHttpPathsBackend `json:"defaultBackend,omitempty"`
+	DefaultBackend   ResourceIngressSpecRulesHttpPathsBackend `json:"defaultBackend"`
 	IngressClassName string                                   `json:"ingressClassName"`
 	Rules            []ResourceIngressSpecRules               `json:"rules"`
 	Tls              []ResourceIngressSpecTls                 `json:"tls"`
@@ -37,8 +37,8 @@ type ResourceIngressSpecRulesHttpPaths struct {
 
 // Deprecated: This type is only to be used in resource/v1 and will be deprecated
 type ResourceIngressSpecRulesHttpPathsBackend struct {
-	Resource ResourceIngressSpecBackendResource `json:"resource,omitempty"`
-	Service  ResourceIngressSpecBackendService  `json:"service,omitempty"`
+	Resource ResourceIngressSpecBackendResource `json:"resource"`
+	Service  ResourceIngressSpecBackendService  `json:"service"`
 }
 
 // Deprecated: This type is only to be used in resource/v1 and will be deprecated
@@ -51,7 +51,7 @@ type ResourceIngressSpecBackendResource struct {
 // Deprecated: This type is only to be used in resource/v1 and will be deprecated
 type ResourceIngressSpecBackendService struct {
 	Name string                                `json:"name,omitempty"`
-	Port ResourceIngressSpecBackendServicePort `json:"port,omitempty"`
+	Port ResourceIngressSpecBackendServicePort `json:"port"`
 }
 
 // Deprecated: This type is only to be used in resource/v1 and will be deprecated

--- a/pkg/apicontracts/apiresourcecontracts/resourcedef_internalclusterorder.go
+++ b/pkg/apicontracts/apiresourcecontracts/resourcedef_internalclusterorder.go
@@ -25,7 +25,7 @@ type ResourceClusterOrderSpec struct {
 	HighAvailability bool                               `json:"highAvailability,omitempty" validate:"boolean"`
 	NodePools        []ResourceClusterOrderSpecNodePool `json:"nodePools,omitempty" validate:"min=1,dive,required"`
 	ServiceTags      map[string]string                  `json:"serviceTags,omitempty"`
-	ProviderConfig   map[string]interface{}             `json:"providerConfig,omitempty"`
+	ProviderConfig   map[string]any                     `json:"providerConfig,omitempty"`
 	OwnerGroup       string                             `json:"ownerGroup,omitempty" validate:"min=1,ne=' '"`
 	K8sVersion       string                             `json:"k8sVersion,omitempty"`
 }

--- a/pkg/apicontracts/apiresourcecontracts/resourcedef_kubernetescluster.go
+++ b/pkg/apicontracts/apiresourcecontracts/resourcedef_kubernetescluster.go
@@ -81,7 +81,7 @@ type ResourceKubernetesClusterStatus struct {
 	Phase             string                                       `json:"phase"`
 	Conditions        []ResourceKubernetesClusterStatusCondition   `json:"conditions"`
 	KubernetesVersion string                                       `json:"kubernetesVersion"`
-	ProviderStatus    map[string]interface{}                       `json:"providerStatus"`
+	ProviderStatus    map[string]any                               `json:"providerStatus"`
 	CreatedTime       string                                       `json:"createdTime"`
 	UpdatedTime       string                                       `json:"updatedTime"`
 	LastObservedTime  string                                       `json:"lastObservedTime"`

--- a/pkg/apicontracts/apiresourcecontracts/resourcedef_tanzukubernetescluster.go
+++ b/pkg/apicontracts/apiresourcecontracts/resourcedef_tanzukubernetescluster.go
@@ -7,7 +7,7 @@ type ResourceTanzuKubernetesCluster struct {
 	Kind       string                               `json:"kind"`
 	Metadata   ResourceTanuzKuberntesMetadata       `json:"metadata"`
 	Spec       ResourceTanuzKuberntesClusterSpec    `json:"spec"`
-	Status     ResourceTanzuKubernetesClusterStatus `json:"status,omitempty"`
+	Status     ResourceTanzuKubernetesClusterStatus `json:"status"`
 }
 
 // Deprecated: This type is only to be used in resource/v1 and will be deprecated

--- a/pkg/apicontracts/messages/ruleset.go
+++ b/pkg/apicontracts/messages/ruleset.go
@@ -53,7 +53,7 @@ type RulesetRuleModel struct {
 	Lifetime RulesetLifetimeType `json:"lifetime" bson:"lifetime"`
 	Service  RulesetServiceType  `json:"service" bson:"service"`
 
-	Slack RulesetSlackModel `json:"slack,omitempty" bson:"slack,omitempty"`
+	Slack RulesetSlackModel `json:"slack" bson:"slack,omitempty"`
 }
 
 type RulesetRuleInput struct {
@@ -61,7 +61,7 @@ type RulesetRuleInput struct {
 	Lifetime RulesetLifetimeType `json:"lifetime"`
 	Service  RulesetServiceType  `json:"service"`
 
-	Slack RulesetSlackModel `json:"slack,omitempty"`
+	Slack RulesetSlackModel `json:"slack"`
 }
 
 type RulesetResourceModel struct {

--- a/pkg/apicontracts/v2/apicontractsv2self/self.go
+++ b/pkg/apicontracts/v2/apicontractsv2self/self.go
@@ -7,9 +7,9 @@ import (
 )
 
 type SelfData struct {
-	Auth identitymodels.AuthInfo     `json:"auth,omitempty"`
+	Auth identitymodels.AuthInfo     `json:"auth"`
 	Type identitymodels.IdentityType `json:"type"`
-	User SelfUser                    `json:"user,omitempty"`
+	User SelfUser                    `json:"user"`
 }
 
 type SelfUser struct {

--- a/pkg/auth/userauth/msgraph/msgraph.go
+++ b/pkg/auth/userauth/msgraph/msgraph.go
@@ -307,7 +307,7 @@ func (g *MsGraphClient) getGroupDisplayNames(ctx context.Context, groups []strin
 	}
 	groupNames := make([]string, len(groups))
 
-	for i := 0; i < len(groups); i++ {
+	for i := range groups {
 		select {
 		case groupname := <-groupsNameChan:
 			groupNames[i] = groupname

--- a/pkg/clients/mongodb/methods.go
+++ b/pkg/clients/mongodb/methods.go
@@ -67,7 +67,7 @@ func NewMongodbQuery(input []bson.M) MongodbQuery {
 	return MongodbQuery(input)
 }
 
-func (rc MongodbCon) Aggregate(ctx context.Context, col string, query []bson.M, value interface{}) error {
+func (rc MongodbCon) Aggregate(ctx context.Context, col string, query []bson.M, value any) error {
 	db := rc.GetMongoDb()
 	resourceCollection := db.Collection(col)
 	results, err := resourceCollection.Aggregate(ctx, query)
@@ -96,7 +96,7 @@ func (rc MongodbCon) UpdateOne(ctx context.Context, col string, filter bson.M, u
 	return *updateResult, nil
 }
 
-func (rc MongodbCon) InsertOne(ctx context.Context, col string, input interface{}) (mongo.InsertOneResult, error) {
+func (rc MongodbCon) InsertOne(ctx context.Context, col string, input any) (mongo.InsertOneResult, error) {
 	db := rc.GetMongoDb()
 	insertResult, err := db.Collection(col).InsertOne(ctx, input)
 	if err != nil {
@@ -106,7 +106,7 @@ func (rc MongodbCon) InsertOne(ctx context.Context, col string, input interface{
 	return *insertResult, nil
 }
 
-func (rc MongodbCon) UpsertOne(ctx context.Context, col string, filter bson.M, update interface{}) (mongo.UpdateResult, error) {
+func (rc MongodbCon) UpsertOne(ctx context.Context, col string, filter bson.M, update any) (mongo.UpdateResult, error) {
 	db := rc.GetMongoDb()
 
 	updateResult, err := db.Collection(col).UpdateOne(ctx, filter, update, options.UpdateOne().SetUpsert(true))
@@ -118,7 +118,7 @@ func (rc MongodbCon) UpsertOne(ctx context.Context, col string, filter bson.M, u
 	return *updateResult, nil
 }
 
-func (rc MongodbCon) FindOne(ctx context.Context, col string, query bson.M, value interface{}) error {
+func (rc MongodbCon) FindOne(ctx context.Context, col string, query bson.M, value any) error {
 	db := rc.GetMongoDb()
 	err := db.Collection(col).FindOne(ctx, query).Decode(value)
 	if err != nil {
@@ -147,7 +147,7 @@ func (rc MongodbCon) Count(ctx context.Context, col string) (int64, error) {
 	return count, nil
 }
 
-func (rc MongodbCon) CountWithFilter(ctx context.Context, col string, filter interface{}) (int64, error) {
+func (rc MongodbCon) CountWithFilter(ctx context.Context, col string, filter any) (int64, error) {
 	db := rc.GetMongoDb()
 	opts := options.Count().SetHint("_id_")
 	count, err := db.Collection(col).CountDocuments(ctx, filter, opts)

--- a/pkg/clients/mongodb/query.go
+++ b/pkg/clients/mongodb/query.go
@@ -9,7 +9,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
-func Aggregate(ctx context.Context, col string, query []bson.M, value interface{}) error {
+func Aggregate(ctx context.Context, col string, query []bson.M, value any) error {
 	db := GetMongoDb()
 	resourceCollection := db.Collection(col)
 	results, err := resourceCollection.Aggregate(ctx, query)
@@ -38,7 +38,7 @@ func UpdateOne(ctx context.Context, col string, filter bson.M, update bson.M) (m
 	return *updateResult, nil
 }
 
-func InsertOne(ctx context.Context, col string, input interface{}) (mongo.InsertOneResult, error) {
+func InsertOne(ctx context.Context, col string, input any) (mongo.InsertOneResult, error) {
 	db := GetMongoDb()
 	insertResult, err := db.Collection(col).InsertOne(ctx, input)
 	if err != nil {
@@ -48,7 +48,7 @@ func InsertOne(ctx context.Context, col string, input interface{}) (mongo.Insert
 	return *insertResult, nil
 }
 
-func FindOne(ctx context.Context, col string, query bson.M, value interface{}) error {
+func FindOne(ctx context.Context, col string, query bson.M, value any) error {
 	db := GetMongoDb()
 	err := db.Collection(col).FindOne(ctx, query).Decode(value)
 	if err != nil {
@@ -77,7 +77,7 @@ func Count(ctx context.Context, col string) (int64, error) {
 	return count, nil
 }
 
-func CountWithFilter(ctx context.Context, col string, filter interface{}) (int64, error) {
+func CountWithFilter(ctx context.Context, col string, filter any) (int64, error) {
 	db := GetMongoDb()
 	opts := options.Count().SetHint("_id_")
 	count, err := db.Collection(col).CountDocuments(ctx, filter, opts)

--- a/pkg/clients/rabbitmqclient/sender.go
+++ b/pkg/clients/rabbitmqclient/sender.go
@@ -12,7 +12,7 @@ import (
 
 var mandatory = false
 
-func (rc rabbitmqcon) SendMessage(ctx context.Context, message any, routing string, extraheaders map[string]interface{}) error {
+func (rc rabbitmqcon) SendMessage(ctx context.Context, message any, routing string, extraheaders map[string]any) error {
 	ctx, span := rc.Trace(ctx, "rabbitmqclient: SendMessage")
 	defer span.End()
 

--- a/pkg/clients/rabbitmqclient/setup.go
+++ b/pkg/clients/rabbitmqclient/setup.go
@@ -34,7 +34,7 @@ type RabbitMQConnection interface {
 	GetChannel() *amqp.Channel
 	RegisterHandler(RabbitMQListnerInterface) error
 	RegisterHandlerWithTTL(RabbitMQListnerInterface, time.Duration) error
-	SendMessage(ctx context.Context, message any, routing string, extraheaders map[string]interface{}) error
+	SendMessage(ctx context.Context, message any, routing string, extraheaders map[string]any) error
 	clients.CommonClient
 }
 

--- a/pkg/clients/redisdb/json.go
+++ b/pkg/clients/redisdb/json.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Deprecated: ReJSON is no longer supported
-func (rc rediscon) GetJSON(ctx context.Context, key string, path string, output interface{}) error {
+func (rc rediscon) GetJSON(ctx context.Context, key string, path string, output any) error {
 	rh := rejson.NewReJSONHandler()
 	rh.SetGoRedisClientWithContext(ctx, rc.Client)
 	value, err := redis.Bytes(rh.JSONGet(key, path))
@@ -24,7 +24,7 @@ func (rc rediscon) GetJSON(ctx context.Context, key string, path string, output 
 }
 
 // Deprecated: ReJSON is no longer supported
-func (rc rediscon) SetJSON(ctx context.Context, key string, path string, value interface{}) error {
+func (rc rediscon) SetJSON(ctx context.Context, key string, path string, value any) error {
 	rh := rejson.NewReJSONHandler()
 	rh.SetGoRedisClientWithContext(ctx, rc.Client)
 

--- a/pkg/clients/redisdb/keyvalue.go
+++ b/pkg/clients/redisdb/keyvalue.go
@@ -16,7 +16,7 @@ func (rc rediscon) Get(ctx context.Context, key string, output *string) error {
 
 }
 
-func (rc rediscon) Set(ctx context.Context, key string, value interface{}, expiration time.Duration) error {
+func (rc rediscon) Set(ctx context.Context, key string, value any, expiration time.Duration) error {
 	err := rc.Client.Set(ctx, key, value, expiration).Err()
 	if err != nil {
 		return err
@@ -40,7 +40,7 @@ func (rc rediscon) Delete(ctx context.Context, key string) error {
 	return nil
 }
 
-func (rc rediscon) MGet(ctx context.Context, keys ...string) ([]interface{}, error) {
+func (rc rediscon) MGet(ctx context.Context, keys ...string) ([]any, error) {
 	return rc.Client.MGet(ctx, keys...).Result()
 }
 

--- a/pkg/clients/redisdb/setup.go
+++ b/pkg/clients/redisdb/setup.go
@@ -27,9 +27,9 @@ const (
 type RedisDB interface {
 	Get(ctx context.Context, key string, output *string) error
 	Keys(ctx context.Context) ([]string, error)
-	Set(ctx context.Context, key string, value interface{}, expiration time.Duration) error
+	Set(ctx context.Context, key string, value any, expiration time.Duration) error
 	Delete(ctx context.Context, key string) error
-	MGet(ctx context.Context, keys ...string) ([]interface{}, error)
+	MGet(ctx context.Context, keys ...string) ([]any, error)
 	SetPipelined(ctx context.Context, items []SetItem) error
 	clients.CommonClient
 }
@@ -37,7 +37,7 @@ type RedisDB interface {
 // SetItem represents a key-value pair with expiration for pipelined SET operations.
 type SetItem struct {
 	Key        string
-	Value      interface{}
+	Value      any
 	Expiration time.Duration
 }
 

--- a/pkg/clients/vaultclient/vaultsecrets.go
+++ b/pkg/clients/vaultclient/vaultsecrets.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Deprecated: Use the VaultClient method instead
-func GetSecret(secretPath string) (map[string]interface{}, error) {
+func GetSecret(secretPath string) (map[string]any, error) {
 	if secretPath == "" {
 		return nil, errors.New("secret path is nil or empty")
 	}
@@ -60,7 +60,7 @@ func GetSecretValue(secretPath string, key string) (string, error) {
 		return "", fmt.Errorf("could not get secret: %w", err)
 	}
 	if data != nil {
-		vaultval, _ := data.Data["data"].(map[string]interface{})
+		vaultval, _ := data.Data["data"].(map[string]any)
 		vaultkey, _ := vaultval[key].(string)
 		return vaultkey, nil
 	}
@@ -68,7 +68,7 @@ func GetSecretValue(secretPath string, key string) (string, error) {
 	return "", nil
 }
 
-func (vc VaultClient) GetSecret(secretPath string) (map[string]interface{}, error) {
+func (vc VaultClient) GetSecret(secretPath string) (map[string]any, error) {
 	if secretPath == "" {
 		return nil, errors.New("secret path is nil or empty")
 	}
@@ -131,7 +131,7 @@ func (vc VaultClient) GetSecretValue(secretPath string, key string) (string, err
 		return "", fmt.Errorf("could not get secret: %w", err)
 	}
 	if data != nil {
-		vaultval, _ := data.Data["data"].(map[string]interface{})
+		vaultval, _ := data.Data["data"].(map[string]any)
 		vaultkey, _ := vaultval[key].(string)
 		return vaultkey, nil
 	}

--- a/pkg/config/rorconfig/configset.go
+++ b/pkg/config/rorconfig/configset.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"os"
 	"reflect"
+	"slices"
 	"time"
 
 	"github.com/NorskHelsenett/ror/pkg/rlog"
@@ -256,12 +257,7 @@ func (rc *rorConfigSet) exportToValue(value reflect.Value, excludeSources []Conf
 }
 
 func isExcludedSource(source ConfigSource, excluded []ConfigSource) bool {
-	for _, e := range excluded {
-		if source == e {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(excluded, source)
 }
 
 func (rc *rorConfigSet) exportRecurseUntagged(field reflect.Value, excludeSources []ConfigSource) error {
@@ -291,8 +287,8 @@ func (rc *rorConfigSet) exportRecurseUntagged(field reflect.Value, excludeSource
 // rorconfig-tagged field in the given struct type (recursing into untagged
 // nested structs).
 func (rc *rorConfigSet) hasAnyTaggedKey(t reflect.Type, excludeSources []ConfigSource) bool {
-	for i := 0; i < t.NumField(); i++ {
-		sf := t.Field(i)
+	for sf := range t.Fields() {
+		sf := sf
 		tag := sf.Tag.Get("rorconfig")
 		if tag != "" {
 			if rc.configs.IsSet(tag) && !isExcludedSource(rc.configs.Get(tag).source, excludeSources) {

--- a/pkg/helpers/jsonhelper/json_helper.go
+++ b/pkg/helpers/jsonhelper/json_helper.go
@@ -12,7 +12,7 @@ import (
 // StringToJson converts a string to a json byte array.
 func StringToJson(key string, value string) []byte {
 	keys := strings.Split(key, ".")
-	data := make(map[string]interface{})
+	data := make(map[string]any)
 
 	currentMap := data
 	for i, key := range keys {
@@ -22,7 +22,7 @@ func StringToJson(key string, value string) []byte {
 		if i == len(keys)-1 {
 			currentMap[key] = value
 		} else {
-			newMap := make(map[string]interface{})
+			newMap := make(map[string]any)
 			currentMap[key] = newMap
 			currentMap = newMap
 		}

--- a/pkg/helpers/kubeconfig/kubeconfig.go
+++ b/pkg/helpers/kubeconfig/kubeconfig.go
@@ -3,8 +3,10 @@ package kubeconfig
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt"
@@ -143,7 +145,7 @@ func (k *KubeConfig) MemberOfGroup(context string, group string) (bool, error) {
 		return false, nil
 	}
 
-	groups, ok := groupsClaim.([]interface{})
+	groups, ok := groupsClaim.([]any)
 	if !ok {
 		return false, nil
 	}
@@ -165,13 +167,9 @@ func (k *KubeConfig) MergeYaml(yaml []byte) *KubeConfig {
 	}
 
 	if k.Config != nil {
-		for key, v := range mergeConfig.Clusters {
-			k.Config.Clusters[key] = v
-		}
+		maps.Copy(k.Config.Clusters, mergeConfig.Clusters)
 
-		for key, v := range mergeConfig.AuthInfos {
-			k.Config.AuthInfos[key] = v
-		}
+		maps.Copy(k.Config.AuthInfos, mergeConfig.AuthInfos)
 
 		for key, v := range mergeConfig.Contexts {
 			old, exists := k.Config.Contexts[key]
@@ -223,11 +221,11 @@ func (k *KubeConfig) HandleErrors() error {
 		return nil
 	}
 
-	var errs string
+	var errs strings.Builder
 	for _, err := range k.Errors {
-		errs += err.Error() + "\n"
+		errs.WriteString(err.Error() + "\n")
 	}
-	return fmt.Errorf("errors: %s", errs)
+	return fmt.Errorf("errors: %s", errs.String())
 }
 
 // SetCurrentContext sets the current context

--- a/pkg/helpers/oidchelper/oidctest/testissuer.go
+++ b/pkg/helpers/oidchelper/oidctest/testissuer.go
@@ -91,7 +91,7 @@ func (ti *TestIssuer) Config(clientIDs ...string) oidchelper.IssuerConfig {
 }
 
 func (ti *TestIssuer) handleDiscovery(w http.ResponseWriter, _ *http.Request) {
-	doc := map[string]interface{}{
+	doc := map[string]any{
 		"issuer":                                ti.IssuerURL,
 		"jwks_uri":                              ti.IssuerURL + "/jwks",
 		"subject_types_supported":               []string{"public"},

--- a/pkg/helpers/stringhelper/string_helper.go
+++ b/pkg/helpers/stringhelper/string_helper.go
@@ -81,8 +81,8 @@ func GetSHA512Hash(data []byte) string {
 }
 
 // JsonToMap converts a json string to a map
-func JsonToMap(jsonStr string) (map[string]interface{}, error) {
-	result := make(map[string]interface{})
+func JsonToMap(jsonStr string) (map[string]any, error) {
+	result := make(map[string]any)
 	err := json.Unmarshal([]byte(jsonStr), &result)
 	return result, err
 }
@@ -99,7 +99,7 @@ func CompareLabels(search map[string]string, labels map[string]string) bool {
 }
 
 // PrettyprintStruct prints a struct in a pretty way
-func PrettyprintStruct(obj interface{}) {
+func PrettyprintStruct(obj any) {
 	empJSON, err := json.MarshalIndent(obj, "", "  ")
 	if err != nil {
 		log.Fatalf(err.Error(), nil)

--- a/pkg/helpers/tokenstoragehelper/tokenstoragehelper.go
+++ b/pkg/helpers/tokenstoragehelper/tokenstoragehelper.go
@@ -236,7 +236,7 @@ func (k *KeyStorageProvider) Verify(tokenString string) (*jwt.Token, error) {
 		parserOptions = append(parserOptions, jwt.WithValidMethods(algs))
 	}
 
-	keyFunc := func(token *jwt.Token) (interface{}, error) {
+	keyFunc := func(token *jwt.Token) (any, error) {
 		rawKid, ok := token.Header["kid"]
 		if !ok {
 			return nil, errors.New("token missing kid header")

--- a/pkg/helpers/tokenstoragehelper/tokenstoragehelper_test.go
+++ b/pkg/helpers/tokenstoragehelper/tokenstoragehelper_test.go
@@ -40,7 +40,7 @@ type stubJWKKey struct {
 	err      error
 }
 
-func (s *stubJWKKey) Set(name string, value interface{}) error {
+func (s *stubJWKKey) Set(name string, value any) error {
 	if name == s.failName {
 		return s.err
 	}
@@ -513,7 +513,7 @@ func TestKeyStorageProviderGetJwksSuccess(t *testing.T) {
 func TestKeyStorageProviderGetJwksFromRawError(t *testing.T) {
 	resetGlobals()
 	privKey := generateRSAKey(t, 1024)
-	jwkFromRawFn = func(interface{}) (jwk.Key, error) {
+	jwkFromRawFn = func(any) (jwk.Key, error) {
 		return nil, errors.New("from raw failure")
 	}
 	defer func() { jwkFromRawFn = jwk.FromRaw }()
@@ -536,7 +536,7 @@ func TestKeyStorageProviderGetJwksKeyIDSetError(t *testing.T) {
 	resetGlobals()
 	privKey := generateRSAKey(t, 1024)
 	original := jwkFromRawFn
-	jwkFromRawFn = func(v interface{}) (jwk.Key, error) {
+	jwkFromRawFn = func(v any) (jwk.Key, error) {
 		key, err := original(v)
 		if err != nil {
 			return nil, err
@@ -563,7 +563,7 @@ func TestKeyStorageProviderGetJwksAlgorithmSetError(t *testing.T) {
 	resetGlobals()
 	privKey := generateRSAKey(t, 1024)
 	original := jwkFromRawFn
-	jwkFromRawFn = func(v interface{}) (jwk.Key, error) {
+	jwkFromRawFn = func(v any) (jwk.Key, error) {
 		key, err := original(v)
 		if err != nil {
 			return nil, err
@@ -590,7 +590,7 @@ func TestKeyStorageProviderGetJwksUsageSetError(t *testing.T) {
 	resetGlobals()
 	privKey := generateRSAKey(t, 1024)
 	original := jwkFromRawFn
-	jwkFromRawFn = func(v interface{}) (jwk.Key, error) {
+	jwkFromRawFn = func(v any) (jwk.Key, error) {
 		key, err := original(v)
 		if err != nil {
 			return nil, err
@@ -873,7 +873,7 @@ func TestGenerateKeyFromRawError(t *testing.T) {
 		return generateRSAKey(t, 1024), nil
 	}
 	original := jwkFromRawFn
-	jwkFromRawFn = func(interface{}) (jwk.Key, error) {
+	jwkFromRawFn = func(any) (jwk.Key, error) {
 		return nil, errors.New("from raw failure")
 	}
 	defer func() {

--- a/pkg/helpers/tokenstoragehelper/vaulttokenadapter/vaulttokenadapter.go
+++ b/pkg/helpers/tokenstoragehelper/vaulttokenadapter/vaulttokenadapter.go
@@ -26,7 +26,7 @@ import (
 // Vault's key-value secrets engine.
 type vaultClient interface {
 	SetSecret(secretPath string, value []byte) (bool, error)
-	GetSecret(secretPath string) (map[string]interface{}, error)
+	GetSecret(secretPath string) (map[string]any, error)
 }
 
 // ensure the HashiCorp vault client satisfies the interface used by the adapter
@@ -72,8 +72,8 @@ func (v *VaultStorageAdapter) Set(ks *tokenstoragehelper.KeyStorageProvider) err
 		return err
 	}
 
-	data := map[string]interface{}{
-		"data": map[string]interface{}{
+	data := map[string]any{
+		"data": map[string]any{
 			"config": string(payload),
 		},
 	}
@@ -104,7 +104,7 @@ func (v *VaultStorageAdapter) Get() (tokenstoragehelper.KeyStorageProvider, erro
 	if err != nil {
 		return tokenstoragehelper.KeyStorageProvider{}, err
 	}
-	data, ok := secretData["data"].(map[string]interface{})
+	data, ok := secretData["data"].(map[string]any)
 	if !ok {
 		return tokenstoragehelper.KeyStorageProvider{}, errors.New("invalid data format in vault secret")
 	}

--- a/pkg/helpers/tokenstoragehelper/vaulttokenadapter/vaulttokenadapter_test.go
+++ b/pkg/helpers/tokenstoragehelper/vaulttokenadapter/vaulttokenadapter_test.go
@@ -12,7 +12,7 @@ import (
 
 type mockVaultClient struct {
 	setSecretFn func(string, []byte) (bool, error)
-	getSecretFn func(string) (map[string]interface{}, error)
+	getSecretFn func(string) (map[string]any, error)
 }
 
 func (m mockVaultClient) SetSecret(secretPath string, value []byte) (bool, error) {
@@ -22,7 +22,7 @@ func (m mockVaultClient) SetSecret(secretPath string, value []byte) (bool, error
 	return m.setSecretFn(secretPath, value)
 }
 
-func (m mockVaultClient) GetSecret(secretPath string) (map[string]interface{}, error) {
+func (m mockVaultClient) GetSecret(secretPath string) (map[string]any, error) {
 	if m.getSecretFn == nil {
 		panic("unexpected call to GetSecret")
 	}
@@ -39,7 +39,7 @@ func TestSetReturnsErrorWhenMarshalPayloadFails(t *testing.T) {
 	originalMarshal := marshalJSON
 	t.Cleanup(func() { marshalJSON = originalMarshal })
 
-	marshalJSON = func(interface{}) ([]byte, error) {
+	marshalJSON = func(any) ([]byte, error) {
 		return nil, errors.New("marshal payload failure")
 	}
 
@@ -58,7 +58,7 @@ func TestSetReturnsErrorWhenMarshalBodyFails(t *testing.T) {
 	t.Cleanup(func() { marshalJSON = originalMarshal })
 
 	callCount := 0
-	marshalJSON = func(v interface{}) ([]byte, error) {
+	marshalJSON = func(v any) ([]byte, error) {
 		callCount++
 		if callCount == 2 {
 			return nil, errors.New("marshal body failure")
@@ -92,7 +92,7 @@ func TestSetPropagatesVaultError(t *testing.T) {
 func TestSetSucceeds(t *testing.T) {
 	captured := struct {
 		path string
-		body map[string]interface{}
+		body map[string]any
 	}{}
 
 	adapter := NewVaultStorageAdapter(mockVaultClient{
@@ -121,7 +121,7 @@ func TestSetSucceeds(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "secret/path", captured.path)
 
-	configValue, ok := captured.body["data"].(map[string]interface{})
+	configValue, ok := captured.body["data"].(map[string]any)
 	require.True(t, ok)
 	storedConfig, ok := configValue["config"].(string)
 	require.True(t, ok)
@@ -142,7 +142,7 @@ func TestGetReturnsErrorWhenVaultClientNil(t *testing.T) {
 
 func TestGetReturnsErrorWhenVaultClientFails(t *testing.T) {
 	adapter := NewVaultStorageAdapter(mockVaultClient{
-		getSecretFn: func(string) (map[string]interface{}, error) {
+		getSecretFn: func(string) (map[string]any, error) {
 			return nil, errors.New("vault failure")
 		},
 	}, "secret/path")
@@ -153,8 +153,8 @@ func TestGetReturnsErrorWhenVaultClientFails(t *testing.T) {
 
 func TestGetReturnsErrorOnInvalidDataMap(t *testing.T) {
 	adapter := NewVaultStorageAdapter(mockVaultClient{
-		getSecretFn: func(string) (map[string]interface{}, error) {
-			return map[string]interface{}{
+		getSecretFn: func(string) (map[string]any, error) {
+			return map[string]any{
 				"data": "not-a-map",
 			}, nil
 		},
@@ -166,9 +166,9 @@ func TestGetReturnsErrorOnInvalidDataMap(t *testing.T) {
 
 func TestGetReturnsErrorOnInvalidConfigType(t *testing.T) {
 	adapter := NewVaultStorageAdapter(mockVaultClient{
-		getSecretFn: func(string) (map[string]interface{}, error) {
-			return map[string]interface{}{
-				"data": map[string]interface{}{
+		getSecretFn: func(string) (map[string]any, error) {
+			return map[string]any{
+				"data": map[string]any{
 					"config": 123,
 				},
 			}, nil
@@ -181,9 +181,9 @@ func TestGetReturnsErrorOnInvalidConfigType(t *testing.T) {
 
 func TestGetReturnsErrorOnUnmarshalFailure(t *testing.T) {
 	adapter := NewVaultStorageAdapter(mockVaultClient{
-		getSecretFn: func(string) (map[string]interface{}, error) {
-			return map[string]interface{}{
-				"data": map[string]interface{}{
+		getSecretFn: func(string) (map[string]any, error) {
+			return map[string]any{
+				"data": map[string]any{
 					"config": "not-json",
 				},
 			}, nil
@@ -217,9 +217,9 @@ func TestGetSucceeds(t *testing.T) {
 	require.NoError(t, err)
 
 	adapter := NewVaultStorageAdapter(mockVaultClient{
-		getSecretFn: func(string) (map[string]interface{}, error) {
-			return map[string]interface{}{
-				"data": map[string]interface{}{
+		getSecretFn: func(string) (map[string]any, error) {
+			return map[string]any{
+				"data": map[string]any{
 					"config": string(payload),
 				},
 			}, nil

--- a/pkg/kubernetes/interregators/clusterinterregator/v2/interface_test.go
+++ b/pkg/kubernetes/interregators/clusterinterregator/v2/interface_test.go
@@ -57,7 +57,6 @@ func TestProviderInterregators_EmptyNodes_NewInterregator_DoesNotPanic(t *testin
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			assert.NotPanics(t, func() {
 				tc.fn([]v1core.Node{})

--- a/pkg/kubernetes/providers/vitistack/vitistackinterregator/v2/vitistackinterregator_test.go
+++ b/pkg/kubernetes/providers/vitistack/vitistackinterregator/v2/vitistackinterregator_test.go
@@ -245,7 +245,6 @@ func TestVitistacktypesMustInitialize(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/kubernetes/providers/vitistack/vitistackinterregator/v3/vitistackinterregator_test.go
+++ b/pkg/kubernetes/providers/vitistack/vitistackinterregator/v3/vitistackinterregator_test.go
@@ -256,7 +256,6 @@ func TestDetectProvider(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/models/aclmodels/aclconvert.go
+++ b/pkg/models/aclmodels/aclconvert.go
@@ -59,16 +59,16 @@ var v3TagToV2Field = buildV3TagMap()
 
 func buildV3TagMap() map[AccessTypeV3]string {
 	m := make(map[AccessTypeV3]string)
-	t := reflect.TypeOf(AclV2ListItemAccess{})
-	for i := range t.NumField() {
-		f := t.Field(i)
+	t := reflect.TypeFor[AclV2ListItemAccess]()
+	for f := range t.Fields() {
+		f := f
 		if tag := f.Tag.Get("v3"); tag != "" {
 			m[AccessTypeV3(tag)] = "access." + f.Name
 		}
 	}
-	t = reflect.TypeOf(AclV2ListItemKubernetes{})
-	for i := range t.NumField() {
-		f := t.Field(i)
+	t = reflect.TypeFor[AclV2ListItemKubernetes]()
+	for f := range t.Fields() {
+		f := f
 		if tag := f.Tag.Get("v3"); tag != "" {
 			m[AccessTypeV3(tag)] = "kubernetes." + f.Name
 		}

--- a/pkg/models/apiresponses/cluster.go
+++ b/pkg/models/apiresponses/cluster.go
@@ -1,7 +1,7 @@
 package apiresponses
 
 type Cluster struct {
-	Status  int                    `json:"status"`
-	Message string                 `json:"message"`
-	Data    map[string]interface{} `json:"data"`
+	Status  int            `json:"status"`
+	Message string         `json:"message"`
+	Data    map[string]any `json:"data"`
 }

--- a/pkg/models/identity/identity.go
+++ b/pkg/models/identity/identity.go
@@ -29,7 +29,7 @@ const (
 
 // Identity is a representation of the consumers identity kept in the context for authentication
 type Identity struct {
-	Auth            AuthInfo     `json:"auth,omitempty"`
+	Auth            AuthInfo     `json:"auth"`
 	Type            IdentityType `json:"type,omitempty"`
 	User            *User        `json:"user,omitempty"`
 	token           string
@@ -40,7 +40,7 @@ type Identity struct {
 type AuthInfo struct {
 	AuthProvider   IdentityProvider `json:"authProvider,omitempty"`
 	AuthProviderID string           `json:"authProviderId,omitempty"`
-	ExpirationTime time.Time        `json:"expirationTime,omitempty"`
+	ExpirationTime time.Time        `json:"expirationTime"`
 }
 
 // The type is a representation of a user identity.

--- a/pkg/rlog/log.go
+++ b/pkg/rlog/log.go
@@ -336,7 +336,7 @@ func Uint(key string, value uint) Field {
 //
 // Returns:
 //   - A Field object that can be used in logging functions
-func Any(key string, value interface{}) Field {
+func Any(key string, value any) Field {
 	return zap.Any(key, value)
 }
 

--- a/pkg/rorresources/resourcequery.go
+++ b/pkg/rorresources/resourcequery.go
@@ -121,7 +121,7 @@ type ResourceQueryOrder struct {
 }
 
 type ResourceQuery struct {
-	VersionKind      schema.GroupVersionKind                      `json:"versionkind,omitempty"`      // memory getparam: apiversion, kind
+	VersionKind      schema.GroupVersionKind                      `json:"versionkind"`                // memory getparam: apiversion, kind
 	Uids             []string                                     `json:"uids,omitempty"`             // memory
 	OwnerRefs        []rorresourceowner.RorResourceOwnerReference `json:"ownerrefs,omitempty"`        // memory
 	Fields           []string                                     `json:"fields,omitempty"`           // post or db

--- a/pkg/rorresources/rorkubernetes/k8s_new.go
+++ b/pkg/rorresources/rorkubernetes/k8s_new.go
@@ -36,7 +36,7 @@ func newCommonResourceFromMapInterface(input map[string]any) v1.ObjectMeta {
 	return *metadataConverted
 }
 
-// NewResourceFromMapInterface creates a new resource from a map[string]interface{}
+// NewResourceFromMapInterface creates a new resource from a map[string]any
 // type provided by the kubernetes universal client.
 func NewResourceFromMapInterface(input map[string]any) *rorresources.Resource {
 	r := rorresources.NewRorResource(input["kind"].(string), input["apiVersion"].(string))

--- a/pkg/rorresources/rorkubernetes/k8s_new.go
+++ b/pkg/rorresources/rorkubernetes/k8s_new.go
@@ -10,7 +10,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func NewResourceSetFromMapInterface(input map[string]interface{}) *rorresources.ResourceSet {
+func NewResourceSetFromMapInterface(input map[string]any) *rorresources.ResourceSet {
 	var rs rorresources.ResourceSet
 	r := NewResourceFromMapInterface(input)
 	rs.Add(r)
@@ -18,8 +18,8 @@ func NewResourceSetFromMapInterface(input map[string]interface{}) *rorresources.
 
 }
 
-func newCommonResourceFromMapInterface(input map[string]interface{}) v1.ObjectMeta {
-	metadata, ok := input["metadata"].(map[string]interface{})
+func newCommonResourceFromMapInterface(input map[string]any) v1.ObjectMeta {
+	metadata, ok := input["metadata"].(map[string]any)
 
 	if !ok {
 		rlog.Warn("could not convert input to metav1.ObjectMeta", rlog.Any("input", input))
@@ -38,7 +38,7 @@ func newCommonResourceFromMapInterface(input map[string]interface{}) v1.ObjectMe
 
 // NewResourceFromMapInterface creates a new resource from a map[string]interface{}
 // type provided by the kubernetes universal client.
-func NewResourceFromMapInterface(input map[string]interface{}) *rorresources.Resource {
+func NewResourceFromMapInterface(input map[string]any) *rorresources.Resource {
 	r := rorresources.NewRorResource(input["kind"].(string), input["apiVersion"].(string))
 	r.SetMetadata(newCommonResourceFromMapInterface(input))
 
@@ -283,7 +283,7 @@ func NewResourceFromMapInterface(input map[string]interface{}) *rorresources.Res
 
 // newNamespaceFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newNamespaceFromMapInterface(input map[string]interface{}) *rortypes.ResourceNamespace {
+func newNamespaceFromMapInterface(input map[string]any) *rortypes.ResourceNamespace {
 	result := rortypes.ResourceNamespace{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -297,7 +297,7 @@ func newNamespaceFromMapInterface(input map[string]interface{}) *rortypes.Resour
 
 // newNodeFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newNodeFromMapInterface(input map[string]interface{}) *rortypes.ResourceNode {
+func newNodeFromMapInterface(input map[string]any) *rortypes.ResourceNode {
 	result := rortypes.ResourceNode{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -311,7 +311,7 @@ func newNodeFromMapInterface(input map[string]interface{}) *rortypes.ResourceNod
 
 // newPersistentVolumeClaimFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newPersistentVolumeClaimFromMapInterface(input map[string]interface{}) *rortypes.ResourcePersistentVolumeClaim {
+func newPersistentVolumeClaimFromMapInterface(input map[string]any) *rortypes.ResourcePersistentVolumeClaim {
 	result := rortypes.ResourcePersistentVolumeClaim{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -325,7 +325,7 @@ func newPersistentVolumeClaimFromMapInterface(input map[string]interface{}) *ror
 
 // newDeploymentFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newDeploymentFromMapInterface(input map[string]interface{}) *rortypes.ResourceDeployment {
+func newDeploymentFromMapInterface(input map[string]any) *rortypes.ResourceDeployment {
 	result := rortypes.ResourceDeployment{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -339,7 +339,7 @@ func newDeploymentFromMapInterface(input map[string]interface{}) *rortypes.Resou
 
 // newStorageClassFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newStorageClassFromMapInterface(input map[string]interface{}) *rortypes.ResourceStorageClass {
+func newStorageClassFromMapInterface(input map[string]any) *rortypes.ResourceStorageClass {
 	result := rortypes.ResourceStorageClass{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -353,7 +353,7 @@ func newStorageClassFromMapInterface(input map[string]interface{}) *rortypes.Res
 
 // newPolicyReportFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newPolicyReportFromMapInterface(input map[string]interface{}) *rortypes.ResourcePolicyReport {
+func newPolicyReportFromMapInterface(input map[string]any) *rortypes.ResourcePolicyReport {
 	result := rortypes.ResourcePolicyReport{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -367,7 +367,7 @@ func newPolicyReportFromMapInterface(input map[string]interface{}) *rortypes.Res
 
 // newApplicationFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newApplicationFromMapInterface(input map[string]interface{}) *rortypes.ResourceApplication {
+func newApplicationFromMapInterface(input map[string]any) *rortypes.ResourceApplication {
 	result := rortypes.ResourceApplication{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -381,7 +381,7 @@ func newApplicationFromMapInterface(input map[string]interface{}) *rortypes.Reso
 
 // newAppProjectFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newAppProjectFromMapInterface(input map[string]interface{}) *rortypes.ResourceAppProject {
+func newAppProjectFromMapInterface(input map[string]any) *rortypes.ResourceAppProject {
 	result := rortypes.ResourceAppProject{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -395,7 +395,7 @@ func newAppProjectFromMapInterface(input map[string]interface{}) *rortypes.Resou
 
 // newCertificateFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newCertificateFromMapInterface(input map[string]interface{}) *rortypes.ResourceCertificate {
+func newCertificateFromMapInterface(input map[string]any) *rortypes.ResourceCertificate {
 	result := rortypes.ResourceCertificate{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -409,7 +409,7 @@ func newCertificateFromMapInterface(input map[string]interface{}) *rortypes.Reso
 
 // newServiceFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newServiceFromMapInterface(input map[string]interface{}) *rortypes.ResourceService {
+func newServiceFromMapInterface(input map[string]any) *rortypes.ResourceService {
 	result := rortypes.ResourceService{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -423,7 +423,7 @@ func newServiceFromMapInterface(input map[string]interface{}) *rortypes.Resource
 
 // newPodFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newPodFromMapInterface(input map[string]interface{}) *rortypes.ResourcePod {
+func newPodFromMapInterface(input map[string]any) *rortypes.ResourcePod {
 	result := rortypes.ResourcePod{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -437,7 +437,7 @@ func newPodFromMapInterface(input map[string]interface{}) *rortypes.ResourcePod 
 
 // newReplicaSetFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newReplicaSetFromMapInterface(input map[string]interface{}) *rortypes.ResourceReplicaSet {
+func newReplicaSetFromMapInterface(input map[string]any) *rortypes.ResourceReplicaSet {
 	result := rortypes.ResourceReplicaSet{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -451,7 +451,7 @@ func newReplicaSetFromMapInterface(input map[string]interface{}) *rortypes.Resou
 
 // newStatefulSetFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newStatefulSetFromMapInterface(input map[string]interface{}) *rortypes.ResourceStatefulSet {
+func newStatefulSetFromMapInterface(input map[string]any) *rortypes.ResourceStatefulSet {
 	result := rortypes.ResourceStatefulSet{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -465,7 +465,7 @@ func newStatefulSetFromMapInterface(input map[string]interface{}) *rortypes.Reso
 
 // newDaemonSetFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newDaemonSetFromMapInterface(input map[string]interface{}) *rortypes.ResourceDaemonSet {
+func newDaemonSetFromMapInterface(input map[string]any) *rortypes.ResourceDaemonSet {
 	result := rortypes.ResourceDaemonSet{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -479,7 +479,7 @@ func newDaemonSetFromMapInterface(input map[string]interface{}) *rortypes.Resour
 
 // newIngressFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newIngressFromMapInterface(input map[string]interface{}) *rortypes.ResourceIngress {
+func newIngressFromMapInterface(input map[string]any) *rortypes.ResourceIngress {
 	result := rortypes.ResourceIngress{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -493,7 +493,7 @@ func newIngressFromMapInterface(input map[string]interface{}) *rortypes.Resource
 
 // newIngressClassFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newIngressClassFromMapInterface(input map[string]interface{}) *rortypes.ResourceIngressClass {
+func newIngressClassFromMapInterface(input map[string]any) *rortypes.ResourceIngressClass {
 	result := rortypes.ResourceIngressClass{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -507,7 +507,7 @@ func newIngressClassFromMapInterface(input map[string]interface{}) *rortypes.Res
 
 // newSbomReportFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newSbomReportFromMapInterface(input map[string]interface{}) *rortypes.ResourceSbomReport {
+func newSbomReportFromMapInterface(input map[string]any) *rortypes.ResourceSbomReport {
 	result := rortypes.ResourceSbomReport{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -521,7 +521,7 @@ func newSbomReportFromMapInterface(input map[string]interface{}) *rortypes.Resou
 
 // newVulnerabilityReportFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newVulnerabilityReportFromMapInterface(input map[string]interface{}) *rortypes.ResourceVulnerabilityReport {
+func newVulnerabilityReportFromMapInterface(input map[string]any) *rortypes.ResourceVulnerabilityReport {
 	result := rortypes.ResourceVulnerabilityReport{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -535,7 +535,7 @@ func newVulnerabilityReportFromMapInterface(input map[string]interface{}) *rorty
 
 // newExposedSecretReportFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newExposedSecretReportFromMapInterface(input map[string]interface{}) *rortypes.ResourceExposedSecretReport {
+func newExposedSecretReportFromMapInterface(input map[string]any) *rortypes.ResourceExposedSecretReport {
 	result := rortypes.ResourceExposedSecretReport{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -549,7 +549,7 @@ func newExposedSecretReportFromMapInterface(input map[string]interface{}) *rorty
 
 // newConfigAuditReportFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newConfigAuditReportFromMapInterface(input map[string]interface{}) *rortypes.ResourceConfigAuditReport {
+func newConfigAuditReportFromMapInterface(input map[string]any) *rortypes.ResourceConfigAuditReport {
 	result := rortypes.ResourceConfigAuditReport{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -563,7 +563,7 @@ func newConfigAuditReportFromMapInterface(input map[string]interface{}) *rortype
 
 // newRbacAssessmentReportFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newRbacAssessmentReportFromMapInterface(input map[string]interface{}) *rortypes.ResourceRbacAssessmentReport {
+func newRbacAssessmentReportFromMapInterface(input map[string]any) *rortypes.ResourceRbacAssessmentReport {
 	result := rortypes.ResourceRbacAssessmentReport{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -577,7 +577,7 @@ func newRbacAssessmentReportFromMapInterface(input map[string]interface{}) *rort
 
 // newTanzuKubernetesClusterFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newTanzuKubernetesClusterFromMapInterface(input map[string]interface{}) *rortypes.ResourceTanzuKubernetesCluster {
+func newTanzuKubernetesClusterFromMapInterface(input map[string]any) *rortypes.ResourceTanzuKubernetesCluster {
 	result := rortypes.ResourceTanzuKubernetesCluster{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -591,7 +591,7 @@ func newTanzuKubernetesClusterFromMapInterface(input map[string]interface{}) *ro
 
 // newTanzuKubernetesReleaseFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newTanzuKubernetesReleaseFromMapInterface(input map[string]interface{}) *rortypes.ResourceTanzuKubernetesRelease {
+func newTanzuKubernetesReleaseFromMapInterface(input map[string]any) *rortypes.ResourceTanzuKubernetesRelease {
 	result := rortypes.ResourceTanzuKubernetesRelease{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -605,7 +605,7 @@ func newTanzuKubernetesReleaseFromMapInterface(input map[string]interface{}) *ro
 
 // newVirtualMachineClassFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newVirtualMachineClassFromMapInterface(input map[string]interface{}) *rortypes.ResourceVirtualMachineClass {
+func newVirtualMachineClassFromMapInterface(input map[string]any) *rortypes.ResourceVirtualMachineClass {
 	result := rortypes.ResourceVirtualMachineClass{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -619,7 +619,7 @@ func newVirtualMachineClassFromMapInterface(input map[string]interface{}) *rorty
 
 // newKubernetesClusterFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newKubernetesClusterFromMapInterface(input map[string]interface{}) *rortypes.ResourceKubernetesCluster {
+func newKubernetesClusterFromMapInterface(input map[string]any) *rortypes.ResourceKubernetesCluster {
 	result := rortypes.ResourceKubernetesCluster{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -633,7 +633,7 @@ func newKubernetesClusterFromMapInterface(input map[string]interface{}) *rortype
 
 // newProviderFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newProviderFromMapInterface(input map[string]interface{}) *rortypes.ResourceProvider {
+func newProviderFromMapInterface(input map[string]any) *rortypes.ResourceProvider {
 	result := rortypes.ResourceProvider{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -647,7 +647,7 @@ func newProviderFromMapInterface(input map[string]interface{}) *rortypes.Resourc
 
 // newWorkspaceFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newWorkspaceFromMapInterface(input map[string]interface{}) *rortypes.ResourceWorkspace {
+func newWorkspaceFromMapInterface(input map[string]any) *rortypes.ResourceWorkspace {
 	result := rortypes.ResourceWorkspace{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -661,7 +661,7 @@ func newWorkspaceFromMapInterface(input map[string]interface{}) *rortypes.Resour
 
 // newKubernetesMachineClassFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newKubernetesMachineClassFromMapInterface(input map[string]interface{}) *rortypes.ResourceKubernetesMachineClass {
+func newKubernetesMachineClassFromMapInterface(input map[string]any) *rortypes.ResourceKubernetesMachineClass {
 	result := rortypes.ResourceKubernetesMachineClass{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -675,7 +675,7 @@ func newKubernetesMachineClassFromMapInterface(input map[string]interface{}) *ro
 
 // newClusterOrderFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newClusterOrderFromMapInterface(input map[string]interface{}) *rortypes.ResourceClusterOrder {
+func newClusterOrderFromMapInterface(input map[string]any) *rortypes.ResourceClusterOrder {
 	result := rortypes.ResourceClusterOrder{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -689,7 +689,7 @@ func newClusterOrderFromMapInterface(input map[string]interface{}) *rortypes.Res
 
 // newProjectFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newProjectFromMapInterface(input map[string]interface{}) *rortypes.ResourceProject {
+func newProjectFromMapInterface(input map[string]any) *rortypes.ResourceProject {
 	result := rortypes.ResourceProject{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -703,7 +703,7 @@ func newProjectFromMapInterface(input map[string]interface{}) *rortypes.Resource
 
 // newConfigurationFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newConfigurationFromMapInterface(input map[string]interface{}) *rortypes.ResourceConfiguration {
+func newConfigurationFromMapInterface(input map[string]any) *rortypes.ResourceConfiguration {
 	result := rortypes.ResourceConfiguration{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -717,7 +717,7 @@ func newConfigurationFromMapInterface(input map[string]interface{}) *rortypes.Re
 
 // newClusterComplianceReportFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newClusterComplianceReportFromMapInterface(input map[string]interface{}) *rortypes.ResourceClusterComplianceReport {
+func newClusterComplianceReportFromMapInterface(input map[string]any) *rortypes.ResourceClusterComplianceReport {
 	result := rortypes.ResourceClusterComplianceReport{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -731,7 +731,7 @@ func newClusterComplianceReportFromMapInterface(input map[string]interface{}) *r
 
 // newClusterVulnerabilityReportFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newClusterVulnerabilityReportFromMapInterface(input map[string]interface{}) *rortypes.ResourceClusterVulnerabilityReport {
+func newClusterVulnerabilityReportFromMapInterface(input map[string]any) *rortypes.ResourceClusterVulnerabilityReport {
 	result := rortypes.ResourceClusterVulnerabilityReport{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -745,7 +745,7 @@ func newClusterVulnerabilityReportFromMapInterface(input map[string]interface{})
 
 // newRouteFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newRouteFromMapInterface(input map[string]interface{}) *rortypes.ResourceRoute {
+func newRouteFromMapInterface(input map[string]any) *rortypes.ResourceRoute {
 	result := rortypes.ResourceRoute{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -759,7 +759,7 @@ func newRouteFromMapInterface(input map[string]interface{}) *rortypes.ResourceRo
 
 // newSlackMessageFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newSlackMessageFromMapInterface(input map[string]interface{}) *rortypes.ResourceSlackMessage {
+func newSlackMessageFromMapInterface(input map[string]any) *rortypes.ResourceSlackMessage {
 	result := rortypes.ResourceSlackMessage{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -773,7 +773,7 @@ func newSlackMessageFromMapInterface(input map[string]interface{}) *rortypes.Res
 
 // newVulnerabilityEventFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newVulnerabilityEventFromMapInterface(input map[string]interface{}) *rortypes.ResourceVulnerabilityEvent {
+func newVulnerabilityEventFromMapInterface(input map[string]any) *rortypes.ResourceVulnerabilityEvent {
 	result := rortypes.ResourceVulnerabilityEvent{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -787,7 +787,7 @@ func newVulnerabilityEventFromMapInterface(input map[string]interface{}) *rortyp
 
 // newVirtualMachineFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newVirtualMachineFromMapInterface(input map[string]interface{}) *rortypes.ResourceVirtualMachine {
+func newVirtualMachineFromMapInterface(input map[string]any) *rortypes.ResourceVirtualMachine {
 	result := rortypes.ResourceVirtualMachine{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -801,7 +801,7 @@ func newVirtualMachineFromMapInterface(input map[string]interface{}) *rortypes.R
 
 // newVirtualMachineVulnerabilityInfoFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newVirtualMachineVulnerabilityInfoFromMapInterface(input map[string]interface{}) *rortypes.ResourceVirtualMachineVulnerabilityInfo {
+func newVirtualMachineVulnerabilityInfoFromMapInterface(input map[string]any) *rortypes.ResourceVirtualMachineVulnerabilityInfo {
 	result := rortypes.ResourceVirtualMachineVulnerabilityInfo{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -815,7 +815,7 @@ func newVirtualMachineVulnerabilityInfoFromMapInterface(input map[string]interfa
 
 // newEndpointsFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newEndpointsFromMapInterface(input map[string]interface{}) *rortypes.ResourceEndpoints {
+func newEndpointsFromMapInterface(input map[string]any) *rortypes.ResourceEndpoints {
 	result := rortypes.ResourceEndpoints{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -829,7 +829,7 @@ func newEndpointsFromMapInterface(input map[string]interface{}) *rortypes.Resour
 
 // newNetworkPolicyFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newNetworkPolicyFromMapInterface(input map[string]interface{}) *rortypes.ResourceNetworkPolicy {
+func newNetworkPolicyFromMapInterface(input map[string]any) *rortypes.ResourceNetworkPolicy {
 	result := rortypes.ResourceNetworkPolicy{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -843,7 +843,7 @@ func newNetworkPolicyFromMapInterface(input map[string]interface{}) *rortypes.Re
 
 // newDatacenterFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newDatacenterFromMapInterface(input map[string]interface{}) *rortypes.ResourceDatacenter {
+func newDatacenterFromMapInterface(input map[string]any) *rortypes.ResourceDatacenter {
 	result := rortypes.ResourceDatacenter{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -857,7 +857,7 @@ func newDatacenterFromMapInterface(input map[string]interface{}) *rortypes.Resou
 
 // newBackupJobFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newBackupJobFromMapInterface(input map[string]interface{}) *rortypes.ResourceBackupJob {
+func newBackupJobFromMapInterface(input map[string]any) *rortypes.ResourceBackupJob {
 	result := rortypes.ResourceBackupJob{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -871,7 +871,7 @@ func newBackupJobFromMapInterface(input map[string]interface{}) *rortypes.Resour
 
 // newBackupRunFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newBackupRunFromMapInterface(input map[string]interface{}) *rortypes.ResourceBackupRun {
+func newBackupRunFromMapInterface(input map[string]any) *rortypes.ResourceBackupRun {
 	result := rortypes.ResourceBackupRun{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -885,7 +885,7 @@ func newBackupRunFromMapInterface(input map[string]interface{}) *rortypes.Resour
 
 // newMachineFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newMachineFromMapInterface(input map[string]interface{}) *rortypes.ResourceMachine {
+func newMachineFromMapInterface(input map[string]any) *rortypes.ResourceMachine {
 	result := rortypes.ResourceMachine{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -899,7 +899,7 @@ func newMachineFromMapInterface(input map[string]interface{}) *rortypes.Resource
 
 // newConfigFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newConfigFromMapInterface(input map[string]interface{}) *rortypes.ResourceConfig {
+func newConfigFromMapInterface(input map[string]any) *rortypes.ResourceConfig {
 	result := rortypes.ResourceConfig{}
 	err := convertUnstructuredToStruct(input, &result)
 
@@ -913,7 +913,7 @@ func newConfigFromMapInterface(input map[string]interface{}) *rortypes.ResourceC
 
 // newUnknownFromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func newUnknownFromMapInterface(input map[string]interface{}) *rortypes.ResourceUnknown {
+func newUnknownFromMapInterface(input map[string]any) *rortypes.ResourceUnknown {
 	result := rortypes.ResourceUnknown{}
 	err := convertUnstructuredToStruct(input, &result)
 

--- a/pkg/rorresources/rorkubernetes/k8s_new.go.tmpl
+++ b/pkg/rorresources/rorkubernetes/k8s_new.go.tmpl
@@ -10,7 +10,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func NewResourceSetFromMapInterface(input map[string]interface{}) *rorresources.ResourceSet {
+func NewResourceSetFromMapInterface(input map[string]any) *rorresources.ResourceSet {
 	var rs rorresources.ResourceSet
 	r := NewResourceFromMapInterface(input)
 	rs.Add(r)
@@ -19,8 +19,8 @@ func NewResourceSetFromMapInterface(input map[string]interface{}) *rorresources.
 }
 
 
-func newCommonResourceFromMapInterface(input map[string]interface{}) v1.ObjectMeta {
-	metadata, ok := input["metadata"].(map[string]interface{})
+func newCommonResourceFromMapInterface(input map[string]any) v1.ObjectMeta {
+	metadata, ok := input["metadata"].(map[string]any)
 
 	if !ok {
 		rlog.Warn("could not convert input to metav1.ObjectMeta", rlog.Any("input", input))
@@ -37,9 +37,9 @@ func newCommonResourceFromMapInterface(input map[string]interface{}) v1.ObjectMe
 	return *metadataConverted
 }
 
-// NewResourceFromMapInterface creates a new resource from a map[string]interface{}
+// NewResourceFromMapInterface creates a new resource from a map[string]any
 // type provided by the kubernetes universal client.
-func NewResourceFromMapInterface(input map[string]interface{}) *rorresources.Resource {
+func NewResourceFromMapInterface(input map[string]any) *rorresources.Resource {
 	r := rorresources.NewRorResource(input["kind"].(string), input["apiVersion"].(string))
 	r.SetMetadata(newCommonResourceFromMapInterface(input))
 
@@ -62,7 +62,7 @@ func NewResourceFromMapInterface(input map[string]interface{}) *rorresources.Res
 {{ range .}}
 // new{{.Kind}}FromMapInterface creates the underlying resource from a unstructured.Unstructured type provided
 // by the kubernetes universal client.
-func new{{.Kind}}FromMapInterface(input map[string]interface{}) *rortypes.Resource{{.Kind}} {
+func new{{.Kind}}FromMapInterface(input map[string]any) *rortypes.Resource{{.Kind}} {
 	result := rortypes.Resource{{.Kind}}{}
 	err := convertUnstructuredToStruct(input, &result)
 

--- a/pkg/rorresources/rorkubernetes/k8s_test.go
+++ b/pkg/rorresources/rorkubernetes/k8s_test.go
@@ -15,10 +15,10 @@ import (
 
 func TestNewResourceSetFromDynamicClientNamespace(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "Namespace",
 			"apiVersion": "v1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-namespace",
 			},
 		},
@@ -34,10 +34,10 @@ func TestNewResourceSetFromDynamicClientNamespace(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientNode(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "Node",
 			"apiVersion": "v1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-node",
 			},
 		},
@@ -53,10 +53,10 @@ func TestNewResourceSetFromDynamicClientNode(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientPersistentVolumeClaim(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "PersistentVolumeClaim",
 			"apiVersion": "v1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-persistentvolumeclaim",
 			},
 		},
@@ -72,10 +72,10 @@ func TestNewResourceSetFromDynamicClientPersistentVolumeClaim(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientDeployment(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "Deployment",
 			"apiVersion": "apps/v1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-deployment",
 			},
 		},
@@ -91,10 +91,10 @@ func TestNewResourceSetFromDynamicClientDeployment(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientStorageClass(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "StorageClass",
 			"apiVersion": "storage.k8s.io/v1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-storageclass",
 			},
 		},
@@ -110,10 +110,10 @@ func TestNewResourceSetFromDynamicClientStorageClass(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientPolicyReport(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "PolicyReport",
 			"apiVersion": "wgpolicyk8s.io/v1alpha2",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-policyreport",
 			},
 		},
@@ -129,10 +129,10 @@ func TestNewResourceSetFromDynamicClientPolicyReport(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientApplication(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "Application",
 			"apiVersion": "argoproj.io/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-application",
 			},
 		},
@@ -148,10 +148,10 @@ func TestNewResourceSetFromDynamicClientApplication(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientAppProject(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "AppProject",
 			"apiVersion": "argoproj.io/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-appproject",
 			},
 		},
@@ -167,10 +167,10 @@ func TestNewResourceSetFromDynamicClientAppProject(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientCertificate(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "Certificate",
 			"apiVersion": "cert-manager.io/v1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-certificate",
 			},
 		},
@@ -186,10 +186,10 @@ func TestNewResourceSetFromDynamicClientCertificate(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientService(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "Service",
 			"apiVersion": "v1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-service",
 			},
 		},
@@ -205,10 +205,10 @@ func TestNewResourceSetFromDynamicClientService(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientPod(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "Pod",
 			"apiVersion": "v1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-pod",
 			},
 		},
@@ -224,10 +224,10 @@ func TestNewResourceSetFromDynamicClientPod(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientReplicaSet(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "ReplicaSet",
 			"apiVersion": "apps/v1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-replicaset",
 			},
 		},
@@ -243,10 +243,10 @@ func TestNewResourceSetFromDynamicClientReplicaSet(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientStatefulSet(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "StatefulSet",
 			"apiVersion": "apps/v1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-statefulset",
 			},
 		},
@@ -262,10 +262,10 @@ func TestNewResourceSetFromDynamicClientStatefulSet(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientDaemonSet(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "DaemonSet",
 			"apiVersion": "apps/v1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-daemonset",
 			},
 		},
@@ -281,10 +281,10 @@ func TestNewResourceSetFromDynamicClientDaemonSet(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientIngress(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "Ingress",
 			"apiVersion": "networking.k8s.io/v1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-ingress",
 			},
 		},
@@ -300,10 +300,10 @@ func TestNewResourceSetFromDynamicClientIngress(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientIngressClass(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "IngressClass",
 			"apiVersion": "networking.k8s.io/v1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-ingressclass",
 			},
 		},
@@ -319,10 +319,10 @@ func TestNewResourceSetFromDynamicClientIngressClass(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientSbomReport(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "SbomReport",
 			"apiVersion": "aquasecurity.github.io/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-sbomreport",
 			},
 		},
@@ -338,10 +338,10 @@ func TestNewResourceSetFromDynamicClientSbomReport(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientVulnerabilityReport(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "VulnerabilityReport",
 			"apiVersion": "aquasecurity.github.io/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-vulnerabilityreport",
 			},
 		},
@@ -357,10 +357,10 @@ func TestNewResourceSetFromDynamicClientVulnerabilityReport(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientExposedSecretReport(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "ExposedSecretReport",
 			"apiVersion": "aquasecurity.github.io/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-exposedsecretreport",
 			},
 		},
@@ -376,10 +376,10 @@ func TestNewResourceSetFromDynamicClientExposedSecretReport(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientConfigAuditReport(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "ConfigAuditReport",
 			"apiVersion": "aquasecurity.github.io/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-configauditreport",
 			},
 		},
@@ -395,10 +395,10 @@ func TestNewResourceSetFromDynamicClientConfigAuditReport(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientRbacAssessmentReport(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "RbacAssessmentReport",
 			"apiVersion": "aquasecurity.github.io/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-rbacassessmentreport",
 			},
 		},
@@ -414,10 +414,10 @@ func TestNewResourceSetFromDynamicClientRbacAssessmentReport(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientTanzuKubernetesCluster(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "TanzuKubernetesCluster",
 			"apiVersion": "run.tanzu.vmware.com/v1alpha3",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-tanzukubernetescluster",
 			},
 		},
@@ -433,10 +433,10 @@ func TestNewResourceSetFromDynamicClientTanzuKubernetesCluster(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientTanzuKubernetesRelease(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "TanzuKubernetesRelease",
 			"apiVersion": "run.tanzu.vmware.com/v1alpha3",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-tanzukubernetesrelease",
 			},
 		},
@@ -452,10 +452,10 @@ func TestNewResourceSetFromDynamicClientTanzuKubernetesRelease(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientVirtualMachineClass(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "VirtualMachineClass",
 			"apiVersion": "vmoperator.vmware.com/v1alpha2",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-virtualmachineclass",
 			},
 		},
@@ -471,10 +471,10 @@ func TestNewResourceSetFromDynamicClientVirtualMachineClass(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientKubernetesCluster(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "KubernetesCluster",
 			"apiVersion": "general.ror.internal/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-kubernetescluster",
 			},
 		},
@@ -490,10 +490,10 @@ func TestNewResourceSetFromDynamicClientKubernetesCluster(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientProvider(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "Provider",
 			"apiVersion": "general.ror.internal/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-provider",
 			},
 		},
@@ -509,10 +509,10 @@ func TestNewResourceSetFromDynamicClientProvider(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientWorkspace(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "Workspace",
 			"apiVersion": "general.ror.internal/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-workspace",
 			},
 		},
@@ -528,10 +528,10 @@ func TestNewResourceSetFromDynamicClientWorkspace(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientKubernetesMachineClass(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "KubernetesMachineClass",
 			"apiVersion": "general.ror.internal/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-kubernetesmachineclass",
 			},
 		},
@@ -547,10 +547,10 @@ func TestNewResourceSetFromDynamicClientKubernetesMachineClass(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientClusterOrder(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "ClusterOrder",
 			"apiVersion": "general.ror.internal/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-clusterorder",
 			},
 		},
@@ -566,10 +566,10 @@ func TestNewResourceSetFromDynamicClientClusterOrder(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientProject(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "Project",
 			"apiVersion": "general.ror.internal/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-project",
 			},
 		},
@@ -585,10 +585,10 @@ func TestNewResourceSetFromDynamicClientProject(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientConfiguration(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "Configuration",
 			"apiVersion": "general.ror.internal/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-configuration",
 			},
 		},
@@ -604,10 +604,10 @@ func TestNewResourceSetFromDynamicClientConfiguration(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientClusterComplianceReport(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "ClusterComplianceReport",
 			"apiVersion": "aquasecurity.github.io/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-clustercompliancereport",
 			},
 		},
@@ -623,10 +623,10 @@ func TestNewResourceSetFromDynamicClientClusterComplianceReport(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientClusterVulnerabilityReport(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "ClusterVulnerabilityReport",
 			"apiVersion": "general.ror.internal/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-clustervulnerabilityreport",
 			},
 		},
@@ -642,10 +642,10 @@ func TestNewResourceSetFromDynamicClientClusterVulnerabilityReport(t *testing.T)
 
 func TestNewResourceSetFromDynamicClientRoute(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "Route",
 			"apiVersion": "general.ror.internal/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-route",
 			},
 		},
@@ -661,10 +661,10 @@ func TestNewResourceSetFromDynamicClientRoute(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientSlackMessage(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "SlackMessage",
 			"apiVersion": "general.ror.internal/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-slackmessage",
 			},
 		},
@@ -680,10 +680,10 @@ func TestNewResourceSetFromDynamicClientSlackMessage(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientVulnerabilityEvent(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "VulnerabilityEvent",
 			"apiVersion": "general.ror.internal/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-vulnerabilityevent",
 			},
 		},
@@ -699,10 +699,10 @@ func TestNewResourceSetFromDynamicClientVulnerabilityEvent(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientVirtualMachine(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "VirtualMachine",
 			"apiVersion": "general.ror.internal/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-virtualmachine",
 			},
 		},
@@ -718,10 +718,10 @@ func TestNewResourceSetFromDynamicClientVirtualMachine(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientVirtualMachineVulnerabilityInfo(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "VirtualMachineVulnerabilityInfo",
 			"apiVersion": "general.ror.internal/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-virtualmachinevulnerabilityinfo",
 			},
 		},
@@ -737,10 +737,10 @@ func TestNewResourceSetFromDynamicClientVirtualMachineVulnerabilityInfo(t *testi
 
 func TestNewResourceSetFromDynamicClientEndpoints(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "Endpoints",
 			"apiVersion": "v1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-endpoints",
 			},
 		},
@@ -756,10 +756,10 @@ func TestNewResourceSetFromDynamicClientEndpoints(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientNetworkPolicy(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "NetworkPolicy",
 			"apiVersion": "networking.k8s.io/v1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-networkpolicy",
 			},
 		},
@@ -775,10 +775,10 @@ func TestNewResourceSetFromDynamicClientNetworkPolicy(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientDatacenter(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "Datacenter",
 			"apiVersion": "infrastructure.ror.internal/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-datacenter",
 			},
 		},
@@ -794,10 +794,10 @@ func TestNewResourceSetFromDynamicClientDatacenter(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientBackupJob(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "BackupJob",
 			"apiVersion": "backup.ror.internal/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-backupjob",
 			},
 		},
@@ -813,10 +813,10 @@ func TestNewResourceSetFromDynamicClientBackupJob(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientBackupRun(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "BackupRun",
 			"apiVersion": "backup.ror.internal/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-backuprun",
 			},
 		},
@@ -832,10 +832,10 @@ func TestNewResourceSetFromDynamicClientBackupRun(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientMachine(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "Machine",
 			"apiVersion": "machine.ror.internal/v1alpha1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-machine",
 			},
 		},
@@ -851,10 +851,10 @@ func TestNewResourceSetFromDynamicClientMachine(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientConfig(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "Config",
 			"apiVersion": "ror.internal/v1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-config",
 			},
 		},
@@ -870,10 +870,10 @@ func TestNewResourceSetFromDynamicClientConfig(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientUnknown(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "Unknown",
 			"apiVersion": "unknown.ror.internal/v1",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-unknown",
 			},
 		},
@@ -889,10 +889,10 @@ func TestNewResourceSetFromDynamicClientUnknown(t *testing.T) {
 
 func TestNewResourceSetFromDynamicClientWrong(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "N00b",
 			"apiVersion": "v900",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-wrong",
 			},
 		},

--- a/pkg/rorresources/rorkubernetes/k8s_test.go.tmpl
+++ b/pkg/rorresources/rorkubernetes/k8s_test.go.tmpl
@@ -15,10 +15,10 @@ import (
 {{ range .}}
 func TestNewResourceSetFromDynamicClient{{.Kind}}(t *testing.T) {
     input := &unstructured.Unstructured{
-        Object: map[string]interface{}{
+        Object: map[string]any{
             "kind":       "{{.Kind}}",
             "apiVersion": "{{.APIVersion}}",
-            "metadata": map[string]interface{}{
+            "metadata": map[string]any{
                 "name": "test-{{.Kind | lower}}",
             },
         },
@@ -35,10 +35,10 @@ func TestNewResourceSetFromDynamicClient{{.Kind}}(t *testing.T) {
 {{ end }}
 func TestNewResourceSetFromDynamicClientWrong(t *testing.T) {
 	input := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "N00b",
 			"apiVersion": "v900",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "test-wrong",
 			},
 		},

--- a/pkg/rorresources/rorkubernetes/resourceconverter.go
+++ b/pkg/rorresources/rorkubernetes/resourceconverter.go
@@ -19,7 +19,7 @@ func convertUnstructuredToStruct(src map[string]any, dst any) error {
 	}
 
 	dstValue := reflect.ValueOf(dst)
-	if dstValue.Kind() != reflect.Ptr || dstValue.Elem().Kind() != reflect.Struct {
+	if dstValue.Kind() != reflect.Pointer || dstValue.Elem().Kind() != reflect.Struct {
 		rlog.Error("Destination must be a pointer to struct", nil)
 		return nil
 	}
@@ -31,7 +31,7 @@ func convertUnstructuredToStruct(src map[string]any, dst any) error {
 }
 
 // convertMapToStruct recursively converts a map to a struct
-func convertMapToStruct(src map[string]interface{}, dstValue reflect.Value, dstType reflect.Type) error {
+func convertMapToStruct(src map[string]any, dstValue reflect.Value, dstType reflect.Type) error {
 	for i := 0; i < dstType.NumField(); i++ {
 		field := dstType.Field(i)
 		fieldValue := dstValue.Field(i)
@@ -74,7 +74,7 @@ func convertMapToStruct(src map[string]interface{}, dstValue reflect.Value, dstT
 }
 
 // setFieldValue sets a field value from an interface{} value using reflection
-func setFieldValue(fieldValue reflect.Value, srcValue interface{}) error {
+func setFieldValue(fieldValue reflect.Value, srcValue any) error {
 	if srcValue == nil {
 		return nil
 	}
@@ -143,7 +143,7 @@ func setFieldValue(fieldValue reflect.Value, srcValue interface{}) error {
 	case reflect.Struct:
 		if srcVal.Kind() == reflect.Map {
 			// Convert map to struct recursively
-			if srcMap, ok := srcValue.(map[string]interface{}); ok {
+			if srcMap, ok := srcValue.(map[string]any); ok {
 				return convertMapToStruct(srcMap, fieldValue, fieldType)
 			}
 		}
@@ -158,11 +158,11 @@ func setFieldValue(fieldValue reflect.Value, srcValue interface{}) error {
 
 	// Handle pointer types
 
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if fieldType.Elem().Kind() == reflect.Struct {
 			// Handle pointer to struct
 			newStruct := reflect.New(fieldType.Elem())
-			if srcMap, ok := srcValue.(map[string]interface{}); ok {
+			if srcMap, ok := srcValue.(map[string]any); ok {
 				if err := convertMapToStruct(srcMap, newStruct.Elem(), fieldType.Elem()); err != nil {
 					return err
 				}

--- a/pkg/rorresources/rortypes/resource_common_models.go
+++ b/pkg/rorresources/rortypes/resource_common_models.go
@@ -46,7 +46,7 @@ func (p ResourceTagProperties) TSName() string {
 // Commonresource defines the minimum resource definition.
 type CommonResource struct {
 	metav1.TypeMeta `json:",inline"`
-	Metadata        metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Metadata        metav1.ObjectMeta `json:"metadata" protobuf:"bytes,1,opt,name=metadata"`
 	RorMeta         ResourceRorMeta   `json:"rormeta"`
 }
 
@@ -56,7 +56,7 @@ type ResourceRorMeta struct {
 	LastReported string                                     `json:"lastReported,omitempty"`
 	Internal     bool                                       `json:"internal,omitempty"`
 	Hash         string                                     `json:"hash,omitempty"`
-	Ownerref     rorresourceowner.RorResourceOwnerReference `json:"ownerref,omitempty"`
+	Ownerref     rorresourceowner.RorResourceOwnerReference `json:"ownerref"`
 	Action       ResourceAction                             `json:"action,omitempty"`
 	Tags         []ResourceTag                              `json:"tags,omitempty"`
 }

--- a/pkg/rorresources/rortypes/resourcedef_clustervulnerabilityreport.go
+++ b/pkg/rorresources/rortypes/resourcedef_clustervulnerabilityreport.go
@@ -41,7 +41,7 @@ type ResourceClusterVulnerabilityReportReportOwner struct {
 
 type ResourceClusterVulnerabilityReportReportStatus struct {
 	Status          VulnerabilityStatus          `json:"status"`
-	Until           metav1.Time                  `json:"until,omitempty"`
+	Until           metav1.Time                  `json:"until"`
 	DismissalReason VulnerabilityDismissalReason `json:"reason,omitempty"`
 	Comment         string                       `json:"comment,omitempty"`
 	RiskAssessment  string                       `json:"riskAssessment,omitempty"`

--- a/pkg/rorresources/rortypes/resourcedef_endpoints.go
+++ b/pkg/rorresources/rortypes/resourcedef_endpoints.go
@@ -14,7 +14,7 @@ type ResourceEndpointSpecSubsetsAddresses struct {
 	Hostname  string                                        `json:"hostname,omitempty"`
 	Ip        string                                        `json:"ip,omitempty"`
 	NodeName  string                                        `json:"nodeName,omitempty"`
-	TargetRef ResourceEndpointSpecSubsetsAddressesTargetRef `json:"targetRef,omitempty"`
+	TargetRef ResourceEndpointSpecSubsetsAddressesTargetRef `json:"targetRef"`
 }
 
 type ResourceEndpointSpecSubsetsAddressesTargetRef struct {
@@ -31,7 +31,7 @@ type ResourceEndpointSpecSubsetsNotReadyAddresses struct {
 	Hostname  string                                                `json:"hostname,omitempty"`
 	Ip        string                                                `json:"ip,omitempty"`
 	NodeName  string                                                `json:"nodeName,omitempty"`
-	TargetRef ResourceEndpointSpecSubsetsNotReadyAddressesTargetRef `json:"targetRef,omitempty"`
+	TargetRef ResourceEndpointSpecSubsetsNotReadyAddressesTargetRef `json:"targetRef"`
 }
 
 type ResourceEndpointSpecSubsetsNotReadyAddressesTargetRef struct {

--- a/pkg/rorresources/rortypes/resourcedef_ingress.go
+++ b/pkg/rorresources/rortypes/resourcedef_ingress.go
@@ -11,7 +11,7 @@ type ResourceIngress struct {
 }
 
 type ResourceIngressSpec struct {
-	DefaultBackend   ResourceIngressSpecRulesHttpPathsBackend `json:"defaultBackend,omitempty"`
+	DefaultBackend   ResourceIngressSpecRulesHttpPathsBackend `json:"defaultBackend"`
 	IngressClassName string                                   `json:"ingressClassName"`
 	Rules            []ResourceIngressSpecRules               `json:"rules"`
 	Tls              []ResourceIngressSpecTls                 `json:"tls"`
@@ -33,8 +33,8 @@ type ResourceIngressSpecRulesHttpPaths struct {
 }
 
 type ResourceIngressSpecRulesHttpPathsBackend struct {
-	Resource ResourceIngressSpecBackendResource `json:"resource,omitempty"`
-	Service  ResourceIngressSpecBackendService  `json:"service,omitempty"`
+	Resource ResourceIngressSpecBackendResource `json:"resource"`
+	Service  ResourceIngressSpecBackendService  `json:"service"`
 }
 
 type ResourceIngressSpecBackendResource struct {
@@ -45,7 +45,7 @@ type ResourceIngressSpecBackendResource struct {
 
 type ResourceIngressSpecBackendService struct {
 	Name string                                `json:"name,omitempty"`
-	Port ResourceIngressSpecBackendServicePort `json:"port,omitempty"`
+	Port ResourceIngressSpecBackendServicePort `json:"port"`
 }
 
 type ResourceIngressSpecBackendServicePort struct {

--- a/pkg/rorresources/rortypes/resourcedef_internalclusterorder.go
+++ b/pkg/rorresources/rortypes/resourcedef_internalclusterorder.go
@@ -17,7 +17,7 @@ type ResourceClusterOrderSpec struct {
 	HighAvailability bool                               `json:"highAvailability" validate:"boolean"`
 	NodePools        []ResourceClusterOrderSpecNodePool `json:"nodePools" validate:"required,min=1,dive,required"`
 	ServiceTags      map[string]string                  `json:"serviceTags,omitempty"`
-	ProviderConfig   map[string]interface{}             `json:"providerConfig,omitempty"`
+	ProviderConfig   map[string]any                     `json:"providerConfig,omitempty"`
 	OwnerGroup       string                             `json:"ownerGroup" validate:"required,min=1,ne=' '"`
 }
 

--- a/pkg/rorresources/rortypes/resourcedef_kubernetescluster.go
+++ b/pkg/rorresources/rortypes/resourcedef_kubernetescluster.go
@@ -36,9 +36,9 @@ type KubernetesClusterAgentStatus struct {
 	Nodes              KubernetesClusterAgentStatusNodes    `json:"nodes,omitzero" bson:"nodes,omitempty"`
 	Versions           map[string]string                    `json:"versions,omitempty" bson:"versions,omitempty"`
 	Urls               map[string]string                    `json:"urls,omitempty" bson:"urls,omitempty"`
-	Endpoint           KubernetesClusterAgentStatusEndpoint `json:"endpoint,omitempty" bson:"endpoint,omitempty"`
-	CreatedAt          time.Time                            `json:"createdAt,omitempty" bson:"createdat,omitempty"`
-	LastSeen           time.Time                            `json:"lastSeen,omitempty" bson:"lastseen,omitempty"`
+	Endpoint           KubernetesClusterAgentStatusEndpoint `json:"endpoint" bson:"endpoint,omitempty"`
+	CreatedAt          time.Time                            `json:"createdAt" bson:"createdat,omitempty"`
+	LastSeen           time.Time                            `json:"lastSeen" bson:"lastseen,omitempty"`
 }
 
 type KubernetesClusterAgentStatusNodes struct {

--- a/pkg/rorresources/rortypes/resourcedef_pod.go
+++ b/pkg/rorresources/rortypes/resourcedef_pod.go
@@ -7,8 +7,8 @@ import (
 // ResourcePod
 // K8s namepace struct
 type ResourcePod struct {
-	Spec   ResourcePodSpec   `json:"spec,omitempty" bson:"spec,omitempty"`
-	Status ResourcePodStatus `json:"status,omitempty" bson:"status,omitempty"`
+	Spec   ResourcePodSpec   `json:"spec" bson:"spec,omitempty"`
+	Status ResourcePodStatus `json:"status" bson:"status,omitempty"`
 }
 
 type ResourcePodSpec struct {

--- a/pkg/rorresources/rortypes/resourcedef_sbomreport.go
+++ b/pkg/rorresources/rortypes/resourcedef_sbomreport.go
@@ -8,7 +8,7 @@ type ResourceSbomReport struct {
 type ResourceSbomReportsReport struct {
 	Scanner         AquaReportScanner           `json:"scanner"`
 	Artifact        ResourceSbomReportsArtifact `json:"artifact"`
-	Registry        ResourceSbomReportsRegistry `json:"registry,omitempty"`
+	Registry        ResourceSbomReportsRegistry `json:"registry"`
 	Summary         ResourceSbomReportsSummary  `json:"summary"`
 	Components      ResourceSbomReportsBom      `json:"components"`
 	UpdateTimestamp string                      `json:"updateTimestamp"`
@@ -35,15 +35,15 @@ type ResourceSbomReportsBom struct {
 	SpecVersion  string                            `json:"specVersion"`
 	SerialNumber string                            `json:"serialNumber,omitempty"`
 	Version      int                               `json:"version,omitempty"`
-	Metadata     ResourceSbomReportsBomMetadata    `json:"metadata,omitempty"`
+	Metadata     ResourceSbomReportsBomMetadata    `json:"metadata"`
 	Components   []ResourceSbomReportsComponent    `json:"components,omitempty"`
 	Dependencies []ResourceSbomReportsComponentDep `json:"dependencies,omitempty"`
 }
 
 type ResourceSbomReportsBomMetadata struct {
 	Timestamp string                              `json:"timestamp,omitempty"`
-	Tools     ResourceSbomReportsBomMetadataTools `json:"tools,omitempty"`
-	Component ResourceSbomReportsComponent        `json:"component,omitempty"`
+	Tools     ResourceSbomReportsBomMetadataTools `json:"tools"`
+	Component ResourceSbomReportsComponent        `json:"component"`
 }
 
 type ResourceSbomReportsBomMetadataTools struct {
@@ -60,7 +60,7 @@ type ResourceSbomReportsComponent struct {
 	Hashes     []ResourceSbomReportsComponentHash     `json:"hashes,omitempty"`
 	Licenses   []ResourceSbomReportsComponentLicense  `json:"licenses,omitempty"`
 	Properties []ResourceSbomReportsComponentProperty `json:"properties,omitempty"`
-	Supplier   ResourceSbomReportsComponentSupplier   `json:"supplier,omitempty"`
+	Supplier   ResourceSbomReportsComponentSupplier   `json:"supplier"`
 }
 
 type ResourceSbomReportsComponentHash struct {
@@ -70,7 +70,7 @@ type ResourceSbomReportsComponentHash struct {
 
 type ResourceSbomReportsComponentLicense struct {
 	Expression string                                     `json:"expression,omitempty"`
-	License    ResourceSbomReportsComponentLicenseDetails `json:"license,omitempty"`
+	License    ResourceSbomReportsComponentLicenseDetails `json:"license"`
 }
 
 type ResourceSbomReportsComponentLicenseDetails struct {

--- a/pkg/rorresources/rortypes/resourcedef_tanzukubernetescluster.go
+++ b/pkg/rorresources/rortypes/resourcedef_tanzukubernetescluster.go
@@ -4,7 +4,7 @@ package rortypes
 // K8s node struct
 type ResourceTanzuKubernetesCluster struct {
 	Spec   ResourceTanuzKuberntesClusterSpec    `json:"spec"`
-	Status ResourceTanzuKubernetesClusterStatus `json:"status,omitempty"`
+	Status ResourceTanzuKubernetesClusterStatus `json:"status"`
 }
 
 type ResourceTanuzKuberntesMetadata struct {

--- a/pkg/services/configservice/configservice.go
+++ b/pkg/services/configservice/configservice.go
@@ -112,7 +112,6 @@ func Template(templatevalue string, ctx context.Context) (string, error) {
 
 	funcMap := make(template.FuncMap, len(Loaders))
 	for source, loader := range Loaders {
-		loader := loader
 		funcMap[source] = func(key string) (string, error) {
 			resolvedKey, err := renderLoaderKeyTemplate(key, data)
 			if err != nil {

--- a/pkg/telemetry/amqptrace/amqp.go
+++ b/pkg/telemetry/amqptrace/amqp.go
@@ -7,7 +7,7 @@ import (
 )
 
 // AmqpHeadersCarrier adapts an AMQP header map for OpenTelemetry context propagation.
-type AmqpHeadersCarrier map[string]interface{}
+type AmqpHeadersCarrier map[string]any
 
 func (a AmqpHeadersCarrier) Get(key string) string {
 	v, ok := a[key]
@@ -32,7 +32,7 @@ func (a AmqpHeadersCarrier) Keys() []string {
 
 // InjectAMQPHeaders injects the trace context from ctx into a new header map
 // suitable for publishing an AMQP message.
-func InjectAMQPHeaders(ctx context.Context) map[string]interface{} {
+func InjectAMQPHeaders(ctx context.Context) map[string]any {
 	h := make(AmqpHeadersCarrier)
 	otel.GetTextMapPropagator().Inject(ctx, h)
 	return h
@@ -40,6 +40,6 @@ func InjectAMQPHeaders(ctx context.Context) map[string]interface{} {
 
 // ExtractAMQPHeaders extracts trace context from AMQP headers into the
 // returned context.
-func ExtractAMQPHeaders(ctx context.Context, headers map[string]interface{}) context.Context {
+func ExtractAMQPHeaders(ctx context.Context, headers map[string]any) context.Context {
 	return otel.GetTextMapPropagator().Extract(ctx, AmqpHeadersCarrier(headers))
 }

--- a/pkg/telemetry/trace/amqp_carrier.go
+++ b/pkg/telemetry/trace/amqp_carrier.go
@@ -6,7 +6,7 @@ import (
 	"go.opentelemetry.io/otel"
 )
 
-type AmqpHeadersCarrier map[string]interface{}
+type AmqpHeadersCarrier map[string]any
 
 func (a AmqpHeadersCarrier) Get(key string) string {
 	v, ok := a[key]
@@ -33,13 +33,13 @@ func (a AmqpHeadersCarrier) Keys() []string {
 }
 
 // InjectAMQPHeaders injects the tracing from the context into the header map
-func InjectAMQPHeaders(ctx context.Context) map[string]interface{} {
+func InjectAMQPHeaders(ctx context.Context) map[string]any {
 	h := make(AmqpHeadersCarrier)
 	otel.GetTextMapPropagator().Inject(ctx, h)
 	return h
 }
 
 // ExtractAMQPHeaders extracts the tracing from the header and puts it into the context
-func ExtractAMQPHeaders(ctx context.Context, headers map[string]interface{}) context.Context {
+func ExtractAMQPHeaders(ctx context.Context, headers map[string]any) context.Context {
 	return otel.GetTextMapPropagator().Extract(ctx, AmqpHeadersCarrier(headers))
 }

--- a/typescript/models/src/resources.ts
+++ b/typescript/models/src/resources.ts
@@ -374,7 +374,7 @@ export interface ResourceEndpointSpecSubsetsNotReadyAddresses {
   hostname?: string;
   ip?: string;
   nodeName?: string;
-  targetRef?: ResourceEndpointSpecSubsetsNotReadyAddressesTargetRef;
+  targetRef: ResourceEndpointSpecSubsetsNotReadyAddressesTargetRef;
 }
 export interface ResourceEndpointSpecSubsetsAddressesTargetRef {
   apiVersion?: string;
@@ -389,7 +389,7 @@ export interface ResourceEndpointSpecSubsetsAddresses {
   hostname?: string;
   ip?: string;
   nodeName?: string;
-  targetRef?: ResourceEndpointSpecSubsetsAddressesTargetRef;
+  targetRef: ResourceEndpointSpecSubsetsAddressesTargetRef;
 }
 export interface ResourceEndpointSpecSubsets {
   addresses?: ResourceEndpointSpecSubsetsAddresses[];
@@ -549,7 +549,7 @@ export interface ResourceRoute {
 }
 export interface ResourceClusterVulnerabilityReportReportStatus {
   status: VulnerabilityStatus;
-  until?: Time;
+  until: Time;
   reason?: VulnerabilityDismissalReason;
   comment?: string;
   riskAssessment?: string;
@@ -736,9 +736,9 @@ export interface KubernetesClusterAgentStatus {
   nodes: KubernetesClusterAgentStatusNodes;
   versions?: { [key: string]: string };
   urls?: { [key: string]: string };
-  endpoint?: KubernetesClusterAgentStatusEndpoint;
-  createdAt?: Time;
-  lastSeen?: Time;
+  endpoint: KubernetesClusterAgentStatusEndpoint;
+  createdAt: Time;
+  lastSeen: Time;
 }
 export interface KubernetesClusterCondition {
   type: string;
@@ -1068,7 +1068,7 @@ export interface ResourceTanuzKuberntesClusterSpec {
 }
 export interface ResourceTanzuKubernetesCluster {
   spec: ResourceTanuzKuberntesClusterSpec;
-  status?: ResourceTanzuKubernetesClusterStatus;
+  status: ResourceTanzuKubernetesClusterStatus;
 }
 export interface ResourceRbacAssessmentReport {
   report: ResourceVulnerabilityReportReport;
@@ -1136,7 +1136,7 @@ export interface ResourceSbomReportsComponentLicenseDetails {
 }
 export interface ResourceSbomReportsComponentLicense {
   expression?: string;
-  license?: ResourceSbomReportsComponentLicenseDetails;
+  license: ResourceSbomReportsComponentLicenseDetails;
 }
 export interface ResourceSbomReportsComponentHash {
   alg?: string;
@@ -1152,22 +1152,22 @@ export interface ResourceSbomReportsComponent {
   hashes?: ResourceSbomReportsComponentHash[];
   licenses?: ResourceSbomReportsComponentLicense[];
   properties?: ResourceSbomReportsComponentProperty[];
-  supplier?: ResourceSbomReportsComponentSupplier;
+  supplier: ResourceSbomReportsComponentSupplier;
 }
 export interface ResourceSbomReportsBomMetadataTools {
   components?: ResourceSbomReportsComponent[];
 }
 export interface ResourceSbomReportsBomMetadata {
   timestamp?: string;
-  tools?: ResourceSbomReportsBomMetadataTools;
-  component?: ResourceSbomReportsComponent;
+  tools: ResourceSbomReportsBomMetadataTools;
+  component: ResourceSbomReportsComponent;
 }
 export interface ResourceSbomReportsBom {
   bomFormat: string;
   specVersion: string;
   serialNumber?: string;
   version?: number;
-  metadata?: ResourceSbomReportsBomMetadata;
+  metadata: ResourceSbomReportsBomMetadata;
   components?: ResourceSbomReportsComponent[];
   dependencies?: ResourceSbomReportsComponentDep[];
 }
@@ -1192,7 +1192,7 @@ export interface AquaReportScanner {
 export interface ResourceSbomReportsReport {
   scanner: AquaReportScanner;
   artifact: ResourceSbomReportsArtifact;
-  registry?: ResourceSbomReportsRegistry;
+  registry: ResourceSbomReportsRegistry;
   summary: ResourceSbomReportsSummary;
   components: ResourceSbomReportsBom;
   updateTimestamp: string;
@@ -1246,7 +1246,7 @@ export interface ResourceIngressSpecBackendServicePort {
 }
 export interface ResourceIngressSpecBackendService {
   name?: string;
-  port?: ResourceIngressSpecBackendServicePort;
+  port: ResourceIngressSpecBackendServicePort;
 }
 export interface ResourceIngressSpecBackendResource {
   apiGroup?: string;
@@ -1254,11 +1254,11 @@ export interface ResourceIngressSpecBackendResource {
   name?: string;
 }
 export interface ResourceIngressSpecRulesHttpPathsBackend {
-  resource?: ResourceIngressSpecBackendResource;
-  service?: ResourceIngressSpecBackendService;
+  resource: ResourceIngressSpecBackendResource;
+  service: ResourceIngressSpecBackendService;
 }
 export interface ResourceIngressSpec {
-  defaultBackend?: ResourceIngressSpecRulesHttpPathsBackend;
+  defaultBackend: ResourceIngressSpecRulesHttpPathsBackend;
   ingressClassName: string;
   rules: ResourceIngressSpecRules[];
   tls: ResourceIngressSpecTls[];
@@ -1333,8 +1333,8 @@ export interface ResourcePodSpec {
   nodeName?: string;
 }
 export interface ResourcePod {
-  spec?: ResourcePodSpec;
-  status?: ResourcePodStatus;
+  spec: ResourcePodSpec;
+  status: ResourcePodStatus;
 }
 export interface IntOrString {
   Type: number;
@@ -1590,7 +1590,7 @@ export interface ResourceRorMeta {
   lastReported?: string;
   internal?: boolean;
   hash?: string;
-  ownerref?: RorResourceOwnerReference;
+  ownerref: RorResourceOwnerReference;
   action?: string;
   tags?: ResourceTag[];
 }
@@ -1633,7 +1633,7 @@ export interface ObjectMeta {
 export interface Resource {
   kind?: string;
   apiVersion?: string;
-  metadata?: ObjectMeta;
+  metadata: ObjectMeta;
   rormeta: ResourceRorMeta;
   namespace?: ResourceNamespace;
   node?: ResourceNode;
@@ -1702,7 +1702,7 @@ export interface GroupVersionKind {
   Kind: string;
 }
 export interface ResourceQuery {
-  versionkind?: GroupVersionKind;
+  versionkind: GroupVersionKind;
   uids?: string[];
   ownerrefs?: RorResourceOwnerReference[];
   fields?: string[];


### PR DESCRIPTION
Ran `go fix` to replace old practices.

- Replaced interface{} with any
- Removed omitempty on json tags where the value would not do anything (structs without pointers)
- Replaced old for loops `for i := 0; i < len(groups); i++` with range `for i := range groups`
- For loop lookup in a slice with slices.Contains()
- For loop map copying with map.Copy()
- String building with strings.Builder()
- TypeOf() with TypeFor()
- reflect.Ptr with reflect.Pointer
- Ineffective variable declerations