### PR TITLE
Add V2 ACL client and related functionality

### DIFF
--- a/pkg/acl/aclstore/cached.go
+++ b/pkg/acl/aclstore/cached.go
@@ -10,6 +10,9 @@ import (
 	"github.com/NorskHelsenett/ror/pkg/clients/redisdb"
 	"github.com/NorskHelsenett/ror/pkg/models/aclmodels"
 	"github.com/NorskHelsenett/ror/pkg/rlog"
+	"github.com/NorskHelsenett/ror/pkg/telemetry/rortracer"
+
+	"go.opentelemetry.io/otel/attribute"
 )
 
 const (
@@ -40,6 +43,10 @@ func NewCachedStore(backend acl.Store, redis redisdb.RedisDB, ttl time.Duration)
 // GetByGroups returns ACL entries for all groups, using Redis cache where possible.
 // Cache misses are backfilled from the backend in a single call.
 func (c *CachedStore) GetByGroups(ctx context.Context, groups []string) (map[string][]aclmodels.AclV3ListItem, error) {
+	ctx, span := rortracer.StartSpan(ctx, "acl.CachedStore.GetByGroups")
+	defer span.End()
+	span.SetAttributes(attribute.Int("acl.groups", len(groups)))
+
 	if len(groups) == 0 {
 		return make(map[string][]aclmodels.AclV3ListItem), nil
 	}
@@ -50,9 +57,15 @@ func (c *CachedStore) GetByGroups(ctx context.Context, groups []string) (map[str
 	hits, misses, cacheErr := c.mget(ctx, groups)
 	if cacheErr != nil {
 		// Redis down — fall through to backend for all groups
+		span.SetAttributes(attribute.Bool("acl.cache_available", false))
 		rlog.Warnc(ctx, "redis cache unavailable, falling through to backend", rlog.Any("error", cacheErr))
 		return c.backend.GetByGroups(ctx, groups)
 	}
+	span.SetAttributes(
+		attribute.Bool("acl.cache_available", true),
+		attribute.Int("acl.cache_hits", len(hits)),
+		attribute.Int("acl.cache_misses", len(misses)),
+	)
 
 	// Add hits to result (preserve backend behavior: omit groups with no entries)
 	for group, entries := range hits {

--- a/pkg/acl/aclstore/cached_test.go
+++ b/pkg/acl/aclstore/cached_test.go
@@ -327,3 +327,152 @@ func TestCached_CacheKeyFormat(t *testing.T) {
 	assert.NoError(t, json.Unmarshal([]byte(val), &entries))
 	assert.Len(t, entries, 1)
 }
+
+// --- V2 cache path ---
+
+func TestCached_V2_CacheMiss_BackfillsFromBackend(t *testing.T) {
+	store, backend, _ := setupTest(t,
+		aclmodels.AclV3ListItem{
+			Group:   "dev-team",
+			Scope:   "KubernetesCluster",
+			Subject: "cluster-1",
+			Access:  []aclmodels.AccessTypeV3{"ror:read"},
+		},
+	)
+
+	result, err := store.GetV2ByGroups(context.Background(), []string{"dev-team"})
+	assert.NoError(t, err)
+	assert.Len(t, result["dev-team"], 1)
+	assert.Equal(t, 1, backend.calls)
+}
+
+func TestCached_V2_CacheHit_SkipsBackend(t *testing.T) {
+	store, backend, _ := setupTest(t,
+		aclmodels.AclV3ListItem{
+			Group:   "dev-team",
+			Scope:   "KubernetesCluster",
+			Subject: "cluster-1",
+			Access:  []aclmodels.AccessTypeV3{"ror:read"},
+		},
+	)
+
+	// First call — cache miss.
+	_, err := store.GetV2ByGroups(context.Background(), []string{"dev-team"})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, backend.calls)
+
+	// Second call — cache hit, backend not consulted.
+	result, err := store.GetV2ByGroups(context.Background(), []string{"dev-team"})
+	assert.NoError(t, err)
+	assert.Len(t, result["dev-team"], 1)
+	assert.Equal(t, 1, backend.calls)
+}
+
+func TestCached_V2_PartialHit_OnlyBackfillsMisses(t *testing.T) {
+	store, backend, _ := setupTest(t,
+		aclmodels.AclV3ListItem{
+			Group:   "dev-team",
+			Scope:   "KubernetesCluster",
+			Subject: "cluster-1",
+			Access:  []aclmodels.AccessTypeV3{"ror:read"},
+		},
+		aclmodels.AclV3ListItem{
+			Group:   "ops-team",
+			Scope:   "KubernetesCluster",
+			Subject: "cluster-1",
+			Access:  []aclmodels.AccessTypeV3{"ror:write"},
+		},
+	)
+
+	// Warm dev-team only.
+	_, err := store.GetV2ByGroups(context.Background(), []string{"dev-team"})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, backend.calls)
+
+	result, err := store.GetV2ByGroups(context.Background(), []string{"dev-team", "ops-team"})
+	assert.NoError(t, err)
+	assert.Len(t, result["dev-team"], 1)
+	assert.Len(t, result["ops-team"], 1)
+	assert.Equal(t, 2, backend.calls)
+}
+
+func TestCached_V2_EmptyGroups(t *testing.T) {
+	store, backend, _ := setupTest(t)
+
+	result, err := store.GetV2ByGroups(context.Background(), []string{})
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	assert.Equal(t, 0, backend.calls)
+}
+
+func TestCached_V2_RedisDown_FallsThrough(t *testing.T) {
+	store, backend, mr := setupTest(t,
+		aclmodels.AclV3ListItem{
+			Group:   "dev-team",
+			Scope:   "KubernetesCluster",
+			Subject: "cluster-1",
+			Access:  []aclmodels.AccessTypeV3{"ror:read"},
+		},
+	)
+
+	mr.Close()
+
+	result, err := store.GetV2ByGroups(context.Background(), []string{"dev-team"})
+	assert.NoError(t, err)
+	assert.Len(t, result["dev-team"], 1)
+	assert.Equal(t, 1, backend.calls)
+}
+
+func TestCached_V2_CacheKeyFormat(t *testing.T) {
+	store, _, mr := setupTest(t,
+		aclmodels.AclV3ListItem{
+			Group:   "dev-team",
+			Scope:   "KubernetesCluster",
+			Subject: "cluster-1",
+			Access:  []aclmodels.AccessTypeV3{"ror:read"},
+		},
+	)
+
+	_, err := store.GetV2ByGroups(context.Background(), []string{"dev-team"})
+	assert.NoError(t, err)
+
+	// V2 uses a distinct key prefix from V3.
+	val, err := mr.Get("acl:v2:group:dev-team")
+	assert.NoError(t, err)
+
+	var entries []aclmodels.AclV2ListItem
+	assert.NoError(t, json.Unmarshal([]byte(val), &entries))
+	assert.Len(t, entries, 1)
+
+	// V3 key must not be populated by a V2 fetch.
+	_, err = mr.Get("acl:v3:group:dev-team")
+	assert.Error(t, err)
+}
+
+func TestCached_Invalidate_ClearsBothV2AndV3(t *testing.T) {
+	store, backend, _ := setupTest(t,
+		aclmodels.AclV3ListItem{
+			Group:   "dev-team",
+			Scope:   "KubernetesCluster",
+			Subject: "cluster-1",
+			Access:  []aclmodels.AccessTypeV3{"ror:read"},
+		},
+	)
+
+	// Warm both caches.
+	_, err := store.GetByGroups(context.Background(), []string{"dev-team"})
+	assert.NoError(t, err)
+	_, err = store.GetV2ByGroups(context.Background(), []string{"dev-team"})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, backend.calls)
+
+	// Invalidate clears both V2 and V3 entries.
+	err = store.Invalidate(context.Background(), "dev-team")
+	assert.NoError(t, err)
+
+	_, err = store.GetByGroups(context.Background(), []string{"dev-team"})
+	assert.NoError(t, err)
+	_, err = store.GetV2ByGroups(context.Background(), []string{"dev-team"})
+	assert.NoError(t, err)
+	assert.Equal(t, 4, backend.calls) // both had to re-fetch
+}

--- a/pkg/acl/aclstore/mongo.go
+++ b/pkg/acl/aclstore/mongo.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 
 	"github.com/NorskHelsenett/ror/pkg/models/aclmodels"
+	"github.com/NorskHelsenett/ror/pkg/telemetry/rortracer"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 const aclCollectionName = "acl"
@@ -31,8 +33,12 @@ type aclRawEntry struct {
 
 // GetByGroups returns all ACL entries as V3 items. V2 entries are converted via aclmodels.V2ToV3.
 func (s *MongoStore) GetByGroups(ctx context.Context, groups []string) (map[string][]aclmodels.AclV3ListItem, error) {
+	ctx, span := rortracer.StartSpan(ctx, "acl.MongoStore.GetByGroups")
+	defer span.End()
+	span.SetAttributes(attribute.Int("acl.groups", len(groups)))
+
 	if s.db == nil {
-		return nil, fmt.Errorf("mongodb not initialized")
+		return nil, rortracer.SpanErrorf(span, "mongodb not initialized")
 	}
 
 	filter := bson.M{
@@ -42,36 +48,40 @@ func (s *MongoStore) GetByGroups(ctx context.Context, groups []string) (map[stri
 
 	cursor, err := s.db.Collection(aclCollectionName).Find(ctx, filter)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query ACL entries: %w", err)
+		return nil, rortracer.SpanError(span, fmt.Errorf("failed to query ACL entries: %w", err))
 	}
 	defer cursor.Close(ctx)
 
 	result := make(map[string][]aclmodels.AclV3ListItem, len(groups))
+	entryCount := 0
 	for cursor.Next(ctx) {
 		var raw aclRawEntry
 		if err := cursor.Decode(&raw); err != nil {
-			return nil, fmt.Errorf("failed to decode ACL entry version: %w", err)
+			return nil, rortracer.SpanError(span, fmt.Errorf("failed to decode ACL entry version: %w", err))
 		}
 
 		switch raw.Version {
 		case 3:
 			var entry aclmodels.AclV3ListItem
 			if err := cursor.Decode(&entry); err != nil {
-				return nil, fmt.Errorf("failed to decode V3 ACL entry: %w", err)
+				return nil, rortracer.SpanError(span, fmt.Errorf("failed to decode V3 ACL entry: %w", err))
 			}
 			result[entry.Group] = append(result[entry.Group], entry)
+			entryCount++
 		case 2:
 			var entry aclmodels.AclV2ListItem
 			if err := cursor.Decode(&entry); err != nil {
-				return nil, fmt.Errorf("failed to decode V2 ACL entry: %w", err)
+				return nil, rortracer.SpanError(span, fmt.Errorf("failed to decode V2 ACL entry: %w", err))
 			}
 			converted := aclmodels.V2ToV3(entry)
 			result[converted.Group] = append(result[converted.Group], converted)
+			entryCount++
 		}
 	}
 	if err := cursor.Err(); err != nil {
-		return nil, fmt.Errorf("cursor error reading ACL entries: %w", err)
+		return nil, rortracer.SpanError(span, fmt.Errorf("cursor error reading ACL entries: %w", err))
 	}
+	span.SetAttributes(attribute.Int("acl.entries", entryCount))
 	return result, nil
 }
 

--- a/pkg/acl/aclstore/scopeexpander_mongo.go
+++ b/pkg/acl/aclstore/scopeexpander_mongo.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/NorskHelsenett/ror/pkg/acl"
 	"github.com/NorskHelsenett/ror/pkg/models/aclmodels/aclscope"
+	"github.com/NorskHelsenett/ror/pkg/telemetry/rortracer"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
-	"go.mongodb.org/mongo-driver/v2/mongo/options"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 const resourceV2Collection = "resourcesv2"
@@ -26,72 +27,187 @@ func NewMongoScopeExpander(db *mongo.Database) *MongoScopeExpander {
 	return &MongoScopeExpander{db: db}
 }
 
-// resourceRef is a minimal projection of a resourcesv2 document.
-type resourceRef struct {
-	UID      string          `bson:"uid"`
-	TypeMeta resourceRefType `bson:"typemeta"`
-}
-
-type resourceRefType struct {
+// ownerRef is a minimal projection of a resourcesv2 document, carrying only
+// the fields needed to build an acl.Ownerref.
+type ownerRef struct {
+	UID  string `bson:"uid"`
 	Kind string `bson:"kind"`
 }
 
 // ExpandScope recursively finds all descendant ownerrefs by walking the
 // ownerref chain in resourcesv2. Returns nil if no resources have the given ownerref.
+//
+// The full descendant subtree is resolved in a single $graphLookup aggregation
+// (resource.uid -> child.rormeta.ownerref.subject) instead of issuing one query
+// per node.
+//
+// Only "owner" nodes are returned: a node is an owner iff at least one other
+// resource in the subtree references its uid as rormeta.ownerref.subject. Leaf
+// resources ("stubs", which own nothing) are excluded — they are never anyone's
+// ownerref.subject, so they would match no resources in an OwnerrefsToFilter
+// query, and they remain reachable through their (owning) parent regardless.
+// This keeps the result small, which matters because the expander runs on every
+// authorized read.
 func (e *MongoScopeExpander) ExpandScope(ctx context.Context, scope aclscope.Scope, subject aclscope.Subject) ([]acl.Ownerref, error) {
-	if e.db == nil {
-		return nil, fmt.Errorf("mongodb not initialized")
+	ctx, span := rortracer.StartSpan(ctx, "acl.MongoScopeExpander.ExpandScope")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("acl.scope", string(scope)),
+		attribute.String("acl.subject", string(subject)),
+	)
+
+	seed := acl.Ownerref{Scope: scope, Subject: subject}
+	expanded, err := e.expandSeeds(ctx, []acl.Ownerref{seed})
+	if err != nil {
+		return nil, rortracer.SpanError(span, err)
 	}
 
-	var result []acl.Ownerref
-	seen := make(map[acl.Ownerref]struct{})
-
-	// BFS queue: start with the given scope+subject
-	type expandItem struct {
-		scope   aclscope.Scope
-		subject aclscope.Subject
-	}
-	queue := []expandItem{{scope: scope, subject: subject}}
-
-	collection := e.db.Collection(resourceV2Collection)
-	projection := bson.M{"uid": 1, "typemeta.kind": 1, "_id": 0}
-
-	for len(queue) > 0 {
-		item := queue[0]
-		queue = queue[1:]
-
-		filter := bson.M{
-			"rormeta.ownerref.scope":   string(item.scope),
-			"rormeta.ownerref.subject": string(item.subject),
-		}
-
-		cursor, err := collection.Find(ctx, filter, options.Find().SetProjection(projection))
-		if err != nil {
-			return nil, fmt.Errorf("failed to query resourcesv2 for scope expansion: %w", err)
-		}
-
-		var refs []resourceRef
-		if err := cursor.All(ctx, &refs); err != nil {
-			return nil, fmt.Errorf("failed to decode resourcesv2 scope expansion results: %w", err)
-		}
-
-		for _, ref := range refs {
-			ownerref := acl.Ownerref{
-				Scope:   aclscope.Scope(ref.TypeMeta.Kind),
-				Subject: aclscope.Subject(ref.UID),
-			}
-			if _, ok := seen[ownerref]; ok {
-				continue
-			}
-			seen[ownerref] = struct{}{}
-			result = append(result, ownerref)
-			// Enqueue for further expansion (children of this resource)
-			queue = append(queue, expandItem{scope: ownerref.Scope, subject: ownerref.Subject})
-		}
-	}
-
+	result := expanded[seed]
+	span.SetAttributes(
+		attribute.Int("acl.queries", 1),
+		attribute.Int("acl.descendants", len(result)),
+	)
 	if len(result) == 0 {
 		return nil, nil
 	}
 	return result, nil
+}
+
+// ExpandScopes expands several scope+subject seeds in a single aggregation,
+// returning the owner descendants for each seed keyed by the seed ownerref.
+// Batching collapses many per-entry round-trips into one. The same owners-only
+// (stub-excluding) rules as ExpandScope apply to every seed.
+func (e *MongoScopeExpander) ExpandScopes(ctx context.Context, seeds []acl.Ownerref) (map[acl.Ownerref][]acl.Ownerref, error) {
+	ctx, span := rortracer.StartSpan(ctx, "acl.MongoScopeExpander.ExpandScopes")
+	defer span.End()
+	span.SetAttributes(attribute.Int("acl.seeds", len(seeds)))
+
+	expanded, err := e.expandSeeds(ctx, seeds)
+	if err != nil {
+		return nil, rortracer.SpanError(span, err)
+	}
+
+	total := 0
+	for _, refs := range expanded {
+		total += len(refs)
+	}
+	span.SetAttributes(
+		attribute.Int("acl.queries", 1),
+		attribute.Int("acl.descendants", total),
+	)
+	return expanded, nil
+}
+
+// expandSeeds resolves the owner-descendants of every seed in one aggregation.
+// Each seed becomes a row (via $unwind of a literal seed array) so that
+// $graphLookup keeps each subtree separate and results can be attributed back to
+// (and cached per) individual seeds. Subjects (uids) are globally unique, so the
+// result rows are keyed by subject and mapped back to the seed ownerref.
+func (e *MongoScopeExpander) expandSeeds(ctx context.Context, seeds []acl.Ownerref) (map[acl.Ownerref][]acl.Ownerref, error) {
+	out := make(map[acl.Ownerref][]acl.Ownerref, len(seeds))
+	if len(seeds) == 0 {
+		return out, nil
+	}
+
+	if e.db == nil {
+		return nil, fmt.Errorf("mongodb not initialized")
+	}
+
+	bySubject := make(map[string]acl.Ownerref, len(seeds))
+	seedVals := bson.A{}
+	for _, s := range seeds {
+		subj := string(s.Subject)
+		if _, ok := bySubject[subj]; ok {
+			continue
+		}
+		bySubject[subj] = s
+		seedVals = append(seedVals, subj)
+		out[s] = nil // ensure every queried seed is present in the result
+	}
+
+	collection := e.db.Collection(resourceV2Collection)
+
+	pipeline := mongo.Pipeline{
+		// Emit one synthetic row per seed subject. Seeds need not exist as
+		// documents; one graph traversal runs per seed instead of one per
+		// direct child (a scope can have thousands of direct children).
+		bson.D{{Key: "$limit", Value: 1}},
+		bson.D{{Key: "$project", Value: bson.D{
+			{Key: "_id", Value: 0},
+			{Key: "seed", Value: bson.D{{Key: "$literal", Value: seedVals}}},
+		}}},
+		bson.D{{Key: "$unwind", Value: "$seed"}},
+		// Recursively gather each seed's subtree by following the ownerref chain
+		// (resource.uid -> child.rormeta.ownerref.subject). uids are globally
+		// unique so connecting on subject alone is sufficient.
+		bson.D{{Key: "$graphLookup", Value: bson.D{
+			{Key: "from", Value: resourceV2Collection},
+			{Key: "startWith", Value: "$seed"},
+			{Key: "connectFromField", Value: "uid"},
+			{Key: "connectToField", Value: "rormeta.ownerref.subject"},
+			{Key: "as", Value: "descendants"},
+		}}},
+		// Build the set of uids that own at least one resource within this
+		// subtree: every uid that appears as some descendant's ownerref.subject.
+		// A leaf resource ("stub") never appears here.
+		bson.D{{Key: "$set", Value: bson.D{
+			{Key: "ownerUids", Value: bson.D{{Key: "$setUnion", Value: bson.A{
+				bson.D{{Key: "$map", Value: bson.D{
+					{Key: "input", Value: "$descendants"},
+					{Key: "as", Value: "d"},
+					{Key: "in", Value: "$$d.rormeta.ownerref.subject"},
+				}}},
+			}}}},
+		}}},
+		// Keep only owner nodes (exclude stubs) and trim to uid + kind.
+		bson.D{{Key: "$project", Value: bson.D{
+			{Key: "_id", Value: 0},
+			{Key: "seed", Value: 1},
+			{Key: "owners", Value: bson.D{{Key: "$map", Value: bson.D{
+				{Key: "input", Value: bson.D{{Key: "$filter", Value: bson.D{
+					{Key: "input", Value: "$descendants"},
+					{Key: "as", Value: "d"},
+					{Key: "cond", Value: bson.D{{Key: "$in", Value: bson.A{"$$d.uid", "$ownerUids"}}}},
+				}}}},
+				{Key: "as", Value: "d"},
+				{Key: "in", Value: bson.D{
+					{Key: "uid", Value: "$$d.uid"},
+					{Key: "kind", Value: "$$d.typemeta.kind"},
+				}},
+			}}}},
+		}}},
+	}
+
+	cursor, err := collection.Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, fmt.Errorf("failed to expand scopes via graph lookup: %w", err)
+	}
+
+	var docs []struct {
+		Seed   string     `bson:"seed"`
+		Owners []ownerRef `bson:"owners"`
+	}
+	if err := cursor.All(ctx, &docs); err != nil {
+		return nil, fmt.Errorf("failed to decode resourcesv2 scope expansion results: %w", err)
+	}
+
+	for _, d := range docs {
+		seed, ok := bySubject[d.Seed]
+		if !ok {
+			continue
+		}
+		var refs []acl.Ownerref
+		seen := make(map[acl.Ownerref]struct{})
+		for _, c := range d.Owners {
+			ref := acl.Ownerref{Scope: aclscope.Scope(c.Kind), Subject: aclscope.Subject(c.UID)}
+			if _, dup := seen[ref]; dup {
+				continue
+			}
+			seen[ref] = struct{}{}
+			refs = append(refs, ref)
+		}
+		out[seed] = refs
+	}
+
+	return out, nil
 }

--- a/pkg/acl/resolver.go
+++ b/pkg/acl/resolver.go
@@ -6,12 +6,63 @@ import (
 
 	"github.com/NorskHelsenett/ror/pkg/models/aclmodels"
 	"github.com/NorskHelsenett/ror/pkg/models/aclmodels/aclscope"
+	"github.com/NorskHelsenett/ror/pkg/telemetry/rortracer"
+
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // Ownerref represents a scope+subject pair that a user has access to.
 type Ownerref struct {
 	Scope   aclscope.Scope
 	Subject aclscope.Subject
+}
+
+// OwnerrefFilter narrows the ownerrefs returned by ResolveOwnerrefs.
+// Each dimension is optional: an empty slice means "no restriction" for that
+// dimension. When Scopes is non-empty, only ownerrefs whose scope is in the set
+// are returned. When Subjects is non-empty, only ownerrefs whose subject is in
+// the set are returned. Both must match when both are set.
+type OwnerrefFilter struct {
+	Scopes   []aclscope.Scope
+	Subjects []aclscope.Subject
+}
+
+// IsEmpty reports whether the filter imposes no restriction.
+func (f OwnerrefFilter) IsEmpty() bool {
+	return len(f.Scopes) == 0 && len(f.Subjects) == 0
+}
+
+// Matches reports whether the given ownerref passes the filter.
+func (f OwnerrefFilter) Matches(ref Ownerref) bool {
+	if len(f.Scopes) > 0 && !slices.Contains(f.Scopes, ref.Scope) {
+		return false
+	}
+	if len(f.Subjects) > 0 && !slices.Contains(f.Subjects, ref.Subject) {
+		return false
+	}
+	return true
+}
+
+// skipExpansion reports whether descendant expansion of an entry with the given
+// scope can be skipped without affecting the filtered result.
+//
+// Descendants are strictly lower in the ownership tree than their seed, so a
+// descendant can never share the seed's scope (a kind does not contain another
+// resource of the same kind in the RoR model). Therefore, when the filter
+// restricts results to exactly the entry's own scope and imposes no subject
+// restriction, no descendant can match and the (potentially expensive) expansion
+// is pure overhead — e.g. a kubernetes:logon lookup filtered to KubernetesCluster
+// never needs to walk into each cluster's resources.
+func (f OwnerrefFilter) skipExpansion(entryScope aclscope.Scope) bool {
+	if len(f.Subjects) > 0 || len(f.Scopes) == 0 {
+		return false
+	}
+	for _, s := range f.Scopes {
+		if s != entryScope {
+			return false
+		}
+	}
+	return true
 }
 
 // Resolver resolves access for a set of groups using a Store.
@@ -47,9 +98,17 @@ func WithScopeExpander(expander ScopeExpander) ResolverOption {
 // ResolveAccess loads ACL entries for all given groups (single round-trip) and returns
 // the union of access types that match the given scope and subject.
 func (r *Resolver) ResolveAccess(ctx context.Context, groups []string, scope aclscope.Scope, subject aclscope.Subject) ([]aclmodels.AccessTypeV3, error) {
+	ctx, span := rortracer.StartSpan(ctx, "acl.Resolver.ResolveAccess")
+	defer span.End()
+	span.SetAttributes(
+		attribute.Int("acl.groups", len(groups)),
+		attribute.String("acl.scope", string(scope)),
+		attribute.String("acl.subject", string(subject)),
+	)
+
 	entriesByGroup, err := r.store.GetByGroups(ctx, groups)
 	if err != nil {
-		return nil, err
+		return nil, rortracer.SpanError(span, err)
 	}
 
 	seen := make(map[aclmodels.AccessTypeV3]struct{})
@@ -67,6 +126,7 @@ func (r *Resolver) ResolveAccess(ctx context.Context, groups []string, scope acl
 	for k := range seen {
 		result = append(result, k)
 	}
+	span.SetAttributes(attribute.Int("acl.access_types", len(result)))
 	return result, nil
 }
 
@@ -74,21 +134,43 @@ func (r *Resolver) ResolveAccess(ctx context.Context, groups []string, scope acl
 // Returns nil (meaning unrestricted) if any entry grants global/all access.
 // When a ScopeExpander is configured, non-leaf scopes (e.g. Project, Workspace) are expanded
 // to include all descendant ownerrefs alongside the original entry.
-func (r *Resolver) ResolveOwnerrefs(ctx context.Context, groups []string, requiredAccess aclmodels.AccessTypeV3) ([]Ownerref, error) {
+//
+// The optional filter narrows the result to specific scopes and/or subjects.
+// An empty filter returns every resolved ownerref.
+func (r *Resolver) ResolveOwnerrefs(ctx context.Context, groups []string, requiredAccess aclmodels.AccessTypeV3, filter OwnerrefFilter) ([]Ownerref, error) {
+	ctx, span := rortracer.StartSpan(ctx, "acl.Resolver.ResolveOwnerrefs")
+	defer span.End()
+	span.SetAttributes(
+		attribute.Int("acl.groups", len(groups)),
+		attribute.String("acl.required_access", string(requiredAccess)),
+		attribute.Bool("acl.expander_enabled", r.expander != nil),
+		attribute.Int("acl.filter_scopes", len(filter.Scopes)),
+		attribute.Int("acl.filter_subjects", len(filter.Subjects)),
+	)
+
 	entriesByGroup, err := r.store.GetByGroups(ctx, groups)
 	if err != nil {
-		return nil, err
+		return nil, rortracer.SpanError(span, err)
 	}
 
 	refs := make([]Ownerref, 0)
 	seen := make(map[Ownerref]struct{})
 
 	addRef := func(ref Ownerref) {
+		if !filter.Matches(ref) {
+			return
+		}
 		if _, ok := seen[ref]; !ok {
 			seen[ref] = struct{}{}
 			refs = append(refs, ref)
 		}
 	}
+
+	// Collect the seeds to expand. Expansion is skipped for an entry when the
+	// filter can only be satisfied by the entry's own scope (see skipExpansion):
+	// descendants are strictly lower in the tree, so they can never match.
+	var seeds []Ownerref
+	seedSeen := make(map[Ownerref]struct{})
 
 	for _, entries := range entriesByGroup {
 		for _, entry := range entries {
@@ -97,24 +179,39 @@ func (r *Resolver) ResolveOwnerrefs(ctx context.Context, groups []string, requir
 			}
 			// Global access — unrestricted
 			if entry.Scope == aclscope.ScopeAll || entry.Subject == aclscope.SubjectAll {
+				span.SetAttributes(attribute.Bool("acl.unrestricted", true))
 				return nil, nil
 			}
 
 			ref := Ownerref{Scope: entry.Scope, Subject: entry.Subject}
 			addRef(ref)
 
-			// Expand to descendants if expander is available
-			if r.expander != nil {
-				descendants, err := r.expander.ExpandScope(ctx, entry.Scope, entry.Subject)
-				if err != nil {
-					return nil, err
-				}
-				for _, d := range descendants {
-					addRef(d)
+			if r.expander != nil && !filter.skipExpansion(entry.Scope) {
+				if _, dup := seedSeen[ref]; !dup {
+					seedSeen[ref] = struct{}{}
+					seeds = append(seeds, ref)
 				}
 			}
 		}
 	}
+
+	// Expand all seeds in a single batched round-trip and add the descendants.
+	if r.expander != nil && len(seeds) > 0 {
+		expanded, err := r.expander.ExpandScopes(ctx, seeds)
+		if err != nil {
+			return nil, rortracer.SpanError(span, err)
+		}
+		for _, descendants := range expanded {
+			for _, d := range descendants {
+				addRef(d)
+			}
+		}
+	}
+
+	span.SetAttributes(
+		attribute.Int("acl.expanded_seeds", len(seeds)),
+		attribute.Int("acl.ownerrefs", len(refs)),
+	)
 	return refs, nil
 }
 

--- a/pkg/acl/resolver_filter_test.go
+++ b/pkg/acl/resolver_filter_test.go
@@ -1,0 +1,494 @@
+package acl_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/NorskHelsenett/ror/pkg/acl"
+	"github.com/NorskHelsenett/ror/pkg/models/aclmodels"
+	"github.com/NorskHelsenett/ror/pkg/models/aclmodels/aclscope"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// recordingExpander records the seeds passed to ExpandScopes so tests can prove
+// that expansion was (or was not) performed for a given seed. It can also be made
+// to fail to exercise error-propagation paths.
+type recordingExpander struct {
+	expansions map[acl.Ownerref][]acl.Ownerref
+	err        error
+
+	scopeCalls  [][]acl.Ownerref // seeds for each ExpandScopes call
+	singleCalls []acl.Ownerref   // args for each ExpandScope call
+}
+
+func (m *recordingExpander) ExpandScope(_ context.Context, scope aclscope.Scope, subject aclscope.Subject) ([]acl.Ownerref, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	key := acl.Ownerref{Scope: scope, Subject: subject}
+	m.singleCalls = append(m.singleCalls, key)
+	return m.expansions[key], nil
+}
+
+func (m *recordingExpander) ExpandScopes(_ context.Context, seeds []acl.Ownerref) (map[acl.Ownerref][]acl.Ownerref, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	m.scopeCalls = append(m.scopeCalls, append([]acl.Ownerref(nil), seeds...))
+	result := make(map[acl.Ownerref][]acl.Ownerref, len(seeds))
+	for _, s := range seeds {
+		result[s] = m.expansions[s]
+	}
+	return result, nil
+}
+
+// expandedSeeds returns the flattened set of seeds that actually reached the backend.
+func (m *recordingExpander) expandedSeeds() []acl.Ownerref {
+	var all []acl.Ownerref
+	for _, c := range m.scopeCalls {
+		all = append(all, c...)
+	}
+	return all
+}
+
+// --- OwnerrefFilter predicate unit tests ---
+
+func TestOwnerrefFilter_IsEmpty(t *testing.T) {
+	assert.True(t, acl.OwnerrefFilter{}.IsEmpty())
+	assert.False(t, acl.OwnerrefFilter{Scopes: []aclscope.Scope{"KubernetesCluster"}}.IsEmpty())
+	assert.False(t, acl.OwnerrefFilter{Subjects: []aclscope.Subject{"cluster-1"}}.IsEmpty())
+	assert.False(t, acl.OwnerrefFilter{
+		Scopes:   []aclscope.Scope{"KubernetesCluster"},
+		Subjects: []aclscope.Subject{"cluster-1"},
+	}.IsEmpty())
+}
+
+func TestOwnerrefFilter_Matches(t *testing.T) {
+	ref := acl.Ownerref{Scope: "KubernetesCluster", Subject: "cluster-1"}
+
+	// Empty filter matches everything.
+	assert.True(t, acl.OwnerrefFilter{}.Matches(ref))
+
+	// Scope-only.
+	assert.True(t, acl.OwnerrefFilter{Scopes: []aclscope.Scope{"KubernetesCluster"}}.Matches(ref))
+	assert.False(t, acl.OwnerrefFilter{Scopes: []aclscope.Scope{"Project"}}.Matches(ref))
+
+	// Subject-only.
+	assert.True(t, acl.OwnerrefFilter{Subjects: []aclscope.Subject{"cluster-1"}}.Matches(ref))
+	assert.False(t, acl.OwnerrefFilter{Subjects: []aclscope.Subject{"cluster-2"}}.Matches(ref))
+
+	// Both set — both dimensions MUST match (guards against too-wide results).
+	assert.True(t, acl.OwnerrefFilter{
+		Scopes:   []aclscope.Scope{"KubernetesCluster"},
+		Subjects: []aclscope.Subject{"cluster-1"},
+	}.Matches(ref))
+	// Scope matches but subject does not → reject.
+	assert.False(t, acl.OwnerrefFilter{
+		Scopes:   []aclscope.Scope{"KubernetesCluster"},
+		Subjects: []aclscope.Subject{"cluster-2"},
+	}.Matches(ref))
+	// Subject matches but scope does not → reject.
+	assert.False(t, acl.OwnerrefFilter{
+		Scopes:   []aclscope.Scope{"Project"},
+		Subjects: []aclscope.Subject{"cluster-1"},
+	}.Matches(ref))
+}
+
+// --- ResolveOwnerrefs with a non-empty filter ---
+
+// A scope filter must drop every ref whose scope is not requested, INCLUDING
+// descendants produced by expansion. Without expansion the project seed would be
+// dropped but the user must still reach its clusters, so the expander must run.
+func TestResolver_ResolveOwnerrefs_ScopeFilter_KeepsOnlyMatchingScope(t *testing.T) {
+	store := newMockStore(
+		aclmodels.AclV3ListItem{
+			Group:   "dev-team",
+			Scope:   "Project",
+			Subject: "proj-1",
+			Access:  []aclmodels.AccessTypeV3{"ror:read"},
+		},
+	)
+	expander := &recordingExpander{
+		expansions: map[acl.Ownerref][]acl.Ownerref{
+			{Scope: "Project", Subject: "proj-1"}: {
+				{Scope: "Workspace", Subject: "ws-dev"},
+				{Scope: "KubernetesCluster", Subject: "cluster-abc"},
+				{Scope: "KubernetesCluster", Subject: "cluster-def"},
+			},
+		},
+	}
+	resolver := acl.NewResolver(store, acl.WithScopeExpander(expander))
+
+	filter := acl.OwnerrefFilter{Scopes: []aclscope.Scope{"KubernetesCluster"}}
+	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"dev-team"}, "ror:read", filter)
+	assert.NoError(t, err)
+
+	// Only the two clusters survive; the Project seed and Workspace are filtered out.
+	assert.Len(t, refs, 2)
+	assert.Contains(t, refs, acl.Ownerref{Scope: "KubernetesCluster", Subject: "cluster-abc"})
+	assert.Contains(t, refs, acl.Ownerref{Scope: "KubernetesCluster", Subject: "cluster-def"})
+	assert.NotContains(t, refs, acl.Ownerref{Scope: "Project", Subject: "proj-1"})
+	assert.NotContains(t, refs, acl.Ownerref{Scope: "Workspace", Subject: "ws-dev"})
+
+	// proj-1 differs from the filter scope, so it had to be expanded.
+	assert.Contains(t, expander.expandedSeeds(), acl.Ownerref{Scope: "Project", Subject: "proj-1"})
+}
+
+// When the filter targets exactly the entry's own scope, expansion is skipped.
+// This must NOT pull in any descendants (which would be a too-wide result) and
+// must NOT call the backend for that seed.
+func TestResolver_ResolveOwnerrefs_ScopeFilter_SkipsExpansionNoLeak(t *testing.T) {
+	store := newMockStore(
+		aclmodels.AclV3ListItem{
+			Group:   "dev-team",
+			Scope:   "KubernetesCluster",
+			Subject: "cluster-1",
+			Access:  []aclmodels.AccessTypeV3{"kubernetes:logon"},
+		},
+		aclmodels.AclV3ListItem{
+			Group:   "dev-team",
+			Scope:   "KubernetesCluster",
+			Subject: "cluster-2",
+			Access:  []aclmodels.AccessTypeV3{"kubernetes:logon"},
+		},
+	)
+	// If the expander were (incorrectly) consulted, it would leak a bogus child.
+	expander := &recordingExpander{
+		expansions: map[acl.Ownerref][]acl.Ownerref{
+			{Scope: "KubernetesCluster", Subject: "cluster-1"}: {
+				{Scope: "KubernetesCluster", Subject: "LEAKED-CHILD"},
+			},
+		},
+	}
+	resolver := acl.NewResolver(store, acl.WithScopeExpander(expander))
+
+	filter := acl.OwnerrefFilter{Scopes: []aclscope.Scope{"KubernetesCluster"}}
+	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"dev-team"}, "kubernetes:logon", filter)
+	assert.NoError(t, err)
+
+	assert.Len(t, refs, 2)
+	assert.Contains(t, refs, acl.Ownerref{Scope: "KubernetesCluster", Subject: "cluster-1"})
+	assert.Contains(t, refs, acl.Ownerref{Scope: "KubernetesCluster", Subject: "cluster-2"})
+	assert.NotContains(t, refs, acl.Ownerref{Scope: "KubernetesCluster", Subject: "LEAKED-CHILD"})
+
+	// Expansion was skipped entirely.
+	assert.Empty(t, expander.expandedSeeds())
+}
+
+// A subject filter restricts the result to specific subjects, even across
+// expansion. Expansion still runs because a subject restriction can match a
+// descendant.
+func TestResolver_ResolveOwnerrefs_SubjectFilter_KeepsOnlyMatchingSubject(t *testing.T) {
+	store := newMockStore(
+		aclmodels.AclV3ListItem{
+			Group:   "dev-team",
+			Scope:   "Project",
+			Subject: "proj-1",
+			Access:  []aclmodels.AccessTypeV3{"ror:read"},
+		},
+	)
+	expander := &recordingExpander{
+		expansions: map[acl.Ownerref][]acl.Ownerref{
+			{Scope: "Project", Subject: "proj-1"}: {
+				{Scope: "KubernetesCluster", Subject: "cluster-abc"},
+				{Scope: "KubernetesCluster", Subject: "cluster-def"},
+			},
+		},
+	}
+	resolver := acl.NewResolver(store, acl.WithScopeExpander(expander))
+
+	filter := acl.OwnerrefFilter{Subjects: []aclscope.Subject{"cluster-abc"}}
+	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"dev-team"}, "ror:read", filter)
+	assert.NoError(t, err)
+
+	assert.Len(t, refs, 1)
+	assert.Contains(t, refs, acl.Ownerref{Scope: "KubernetesCluster", Subject: "cluster-abc"})
+	assert.NotContains(t, refs, acl.Ownerref{Scope: "KubernetesCluster", Subject: "cluster-def"})
+}
+
+// Both dimensions set: only the single ref matching scope AND subject survives.
+func TestResolver_ResolveOwnerrefs_ScopeAndSubjectFilter(t *testing.T) {
+	store := newMockStore(
+		aclmodels.AclV3ListItem{
+			Group:   "dev-team",
+			Scope:   "Project",
+			Subject: "proj-1",
+			Access:  []aclmodels.AccessTypeV3{"ror:read"},
+		},
+	)
+	expander := &recordingExpander{
+		expansions: map[acl.Ownerref][]acl.Ownerref{
+			{Scope: "Project", Subject: "proj-1"}: {
+				{Scope: "Workspace", Subject: "cluster-def"}, // subject matches but scope does not
+				{Scope: "KubernetesCluster", Subject: "cluster-def"},
+				{Scope: "KubernetesCluster", Subject: "cluster-abc"},
+			},
+		},
+	}
+	resolver := acl.NewResolver(store, acl.WithScopeExpander(expander))
+
+	filter := acl.OwnerrefFilter{
+		Scopes:   []aclscope.Scope{"KubernetesCluster"},
+		Subjects: []aclscope.Subject{"cluster-def"},
+	}
+	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"dev-team"}, "ror:read", filter)
+	assert.NoError(t, err)
+
+	assert.Len(t, refs, 1)
+	assert.Contains(t, refs, acl.Ownerref{Scope: "KubernetesCluster", Subject: "cluster-def"})
+}
+
+// Mixed seeds: a leaf seed matching the filter scope is NOT expanded, while a
+// higher seed of a different scope IS expanded to surface its matching children.
+func TestResolver_ResolveOwnerrefs_ScopeFilter_MixedSeeds(t *testing.T) {
+	store := newMockStore(
+		aclmodels.AclV3ListItem{
+			Group:   "dev-team",
+			Scope:   "KubernetesCluster",
+			Subject: "cluster-1",
+			Access:  []aclmodels.AccessTypeV3{"kubernetes:logon"},
+		},
+		aclmodels.AclV3ListItem{
+			Group:   "dev-team",
+			Scope:   "Project",
+			Subject: "proj-1",
+			Access:  []aclmodels.AccessTypeV3{"kubernetes:logon"},
+		},
+	)
+	expander := &recordingExpander{
+		expansions: map[acl.Ownerref][]acl.Ownerref{
+			{Scope: "Project", Subject: "proj-1"}: {
+				{Scope: "KubernetesCluster", Subject: "cluster-abc"},
+			},
+			// cluster-1 has a (bogus) expansion that must never be consulted.
+			{Scope: "KubernetesCluster", Subject: "cluster-1"}: {
+				{Scope: "KubernetesCluster", Subject: "LEAKED-CHILD"},
+			},
+		},
+	}
+	resolver := acl.NewResolver(store, acl.WithScopeExpander(expander))
+
+	filter := acl.OwnerrefFilter{Scopes: []aclscope.Scope{"KubernetesCluster"}}
+	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"dev-team"}, "kubernetes:logon", filter)
+	assert.NoError(t, err)
+
+	assert.Len(t, refs, 2)
+	assert.Contains(t, refs, acl.Ownerref{Scope: "KubernetesCluster", Subject: "cluster-1"})
+	assert.Contains(t, refs, acl.Ownerref{Scope: "KubernetesCluster", Subject: "cluster-abc"})
+	assert.NotContains(t, refs, acl.Ownerref{Scope: "KubernetesCluster", Subject: "LEAKED-CHILD"})
+
+	// Only proj-1 was expanded; cluster-1 was skipped.
+	seeds := expander.expandedSeeds()
+	assert.Contains(t, seeds, acl.Ownerref{Scope: "Project", Subject: "proj-1"})
+	assert.NotContains(t, seeds, acl.Ownerref{Scope: "KubernetesCluster", Subject: "cluster-1"})
+}
+
+// A filter that matches nothing must return an empty, NON-nil slice. Returning
+// nil here would be read as "unrestricted" downstream — the worst possible
+// too-wide result.
+func TestResolver_ResolveOwnerrefs_Filter_NoMatch_EmptyNotNil(t *testing.T) {
+	store := newMockStore(
+		aclmodels.AclV3ListItem{
+			Group:   "dev-team",
+			Scope:   "KubernetesCluster",
+			Subject: "cluster-1",
+			Access:  []aclmodels.AccessTypeV3{"ror:read"},
+		},
+	)
+	resolver := acl.NewResolver(store)
+
+	filter := acl.OwnerrefFilter{Scopes: []aclscope.Scope{"Project"}}
+	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"dev-team"}, "ror:read", filter)
+	assert.NoError(t, err)
+	assert.Empty(t, refs)
+	assert.NotNil(t, refs)
+}
+
+// Global/unrestricted grants short-circuit and return nil REGARDLESS of the
+// filter. This pins the (intentional) behaviour: a global grant means the caller
+// is unrestricted, so a narrowing filter cannot make the result safer here.
+func TestResolver_ResolveOwnerrefs_GlobalGrant_IgnoresFilter(t *testing.T) {
+	store := newMockStore(
+		aclmodels.AclV3ListItem{
+			Group:   "admins",
+			Scope:   "all",
+			Subject: aclscope.SubjectAll,
+			Access:  []aclmodels.AccessTypeV3{"ror:read"},
+		},
+	)
+	expander := &recordingExpander{}
+	resolver := acl.NewResolver(store, acl.WithScopeExpander(expander))
+
+	filter := acl.OwnerrefFilter{Scopes: []aclscope.Scope{"KubernetesCluster"}}
+	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"admins"}, "ror:read", filter)
+	assert.NoError(t, err)
+	assert.Nil(t, refs) // nil = unrestricted
+	assert.Empty(t, expander.expandedSeeds())
+}
+
+// An error from the expander backend must propagate, never silently yielding a
+// partial (and possibly misleading) result.
+func TestResolver_ResolveOwnerrefs_ExpanderError_Propagates(t *testing.T) {
+	store := newMockStore(
+		aclmodels.AclV3ListItem{
+			Group:   "dev-team",
+			Scope:   "Project",
+			Subject: "proj-1",
+			Access:  []aclmodels.AccessTypeV3{"ror:read"},
+		},
+	)
+	expander := &recordingExpander{err: fmt.Errorf("mongo down")}
+	resolver := acl.NewResolver(store, acl.WithScopeExpander(expander))
+
+	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"dev-team"}, "ror:read", acl.OwnerrefFilter{})
+	assert.Error(t, err)
+	assert.Nil(t, refs)
+}
+
+// --- CachedScopeExpander.ExpandScopes (batched) ---
+
+func TestCachedScopeExpander_ExpandScopes_AllMiss_OneBackendCall(t *testing.T) {
+	backend := &recordingExpander{
+		expansions: map[acl.Ownerref][]acl.Ownerref{
+			{Scope: "Project", Subject: "proj-1"}:   {{Scope: "KubernetesCluster", Subject: "c1"}},
+			{Scope: "Workspace", Subject: "ws-dev"}: {{Scope: "KubernetesCluster", Subject: "c2"}},
+		},
+	}
+	cached := acl.NewCachedScopeExpander(backend, 5*time.Minute)
+
+	seeds := []acl.Ownerref{
+		{Scope: "Project", Subject: "proj-1"},
+		{Scope: "Workspace", Subject: "ws-dev"},
+	}
+	result, err := cached.ExpandScopes(context.Background(), seeds)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, []acl.Ownerref{{Scope: "KubernetesCluster", Subject: "c1"}}, result[seeds[0]])
+	assert.Equal(t, []acl.Ownerref{{Scope: "KubernetesCluster", Subject: "c2"}}, result[seeds[1]])
+
+	// All misses resolved in a single batched backend call.
+	assert.Len(t, backend.scopeCalls, 1)
+	assert.ElementsMatch(t, seeds, backend.scopeCalls[0])
+}
+
+func TestCachedScopeExpander_ExpandScopes_PartialHit_OnlyMissesHitBackend(t *testing.T) {
+	backend := &recordingExpander{
+		expansions: map[acl.Ownerref][]acl.Ownerref{
+			{Scope: "Project", Subject: "proj-1"}:   {{Scope: "KubernetesCluster", Subject: "c1"}},
+			{Scope: "Workspace", Subject: "ws-dev"}: {{Scope: "KubernetesCluster", Subject: "c2"}},
+		},
+	}
+	cached := acl.NewCachedScopeExpander(backend, 5*time.Minute)
+
+	// Warm proj-1 only.
+	_, err := cached.ExpandScopes(context.Background(), []acl.Ownerref{{Scope: "Project", Subject: "proj-1"}})
+	assert.NoError(t, err)
+	assert.Len(t, backend.scopeCalls, 1)
+
+	// Request both — proj-1 from cache, ws-dev from backend.
+	result, err := cached.ExpandScopes(context.Background(), []acl.Ownerref{
+		{Scope: "Project", Subject: "proj-1"},
+		{Scope: "Workspace", Subject: "ws-dev"},
+	})
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+
+	// Second backend call contains only the miss.
+	assert.Len(t, backend.scopeCalls, 2)
+	assert.Equal(t, []acl.Ownerref{{Scope: "Workspace", Subject: "ws-dev"}}, backend.scopeCalls[1])
+}
+
+func TestCachedScopeExpander_ExpandScopes_AllHit_NoBackendCall(t *testing.T) {
+	backend := &recordingExpander{
+		expansions: map[acl.Ownerref][]acl.Ownerref{
+			{Scope: "Project", Subject: "proj-1"}: {{Scope: "KubernetesCluster", Subject: "c1"}},
+		},
+	}
+	cached := acl.NewCachedScopeExpander(backend, 5*time.Minute)
+
+	seeds := []acl.Ownerref{{Scope: "Project", Subject: "proj-1"}}
+	_, err := cached.ExpandScopes(context.Background(), seeds)
+	assert.NoError(t, err)
+	assert.Len(t, backend.scopeCalls, 1)
+
+	_, err = cached.ExpandScopes(context.Background(), seeds)
+	assert.NoError(t, err)
+	assert.Len(t, backend.scopeCalls, 1) // still 1, served from cache
+}
+
+func TestCachedScopeExpander_ExpandScopes_DuplicateSeeds_BackendOnce(t *testing.T) {
+	backend := &recordingExpander{
+		expansions: map[acl.Ownerref][]acl.Ownerref{
+			{Scope: "Project", Subject: "proj-1"}: {{Scope: "KubernetesCluster", Subject: "c1"}},
+		},
+	}
+	cached := acl.NewCachedScopeExpander(backend, 5*time.Minute)
+
+	seed := acl.Ownerref{Scope: "Project", Subject: "proj-1"}
+	result, err := cached.ExpandScopes(context.Background(), []acl.Ownerref{seed, seed, seed})
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+
+	// Duplicate seeds collapse to a single backend lookup.
+	assert.Len(t, backend.scopeCalls, 1)
+	assert.Equal(t, []acl.Ownerref{seed}, backend.scopeCalls[0])
+}
+
+func TestCachedScopeExpander_ExpandScopes_NilExpansion_Cached(t *testing.T) {
+	backend := &recordingExpander{expansions: map[acl.Ownerref][]acl.Ownerref{}}
+	cached := acl.NewCachedScopeExpander(backend, 5*time.Minute)
+
+	seed := acl.Ownerref{Scope: "KubernetesCluster", Subject: "leaf"}
+	result, err := cached.ExpandScopes(context.Background(), []acl.Ownerref{seed})
+	assert.NoError(t, err)
+	assert.Nil(t, result[seed])
+	assert.Len(t, backend.scopeCalls, 1)
+
+	// Second call served from cache despite the nil expansion.
+	result, err = cached.ExpandScopes(context.Background(), []acl.Ownerref{seed})
+	assert.NoError(t, err)
+	assert.Nil(t, result[seed])
+	assert.Len(t, backend.scopeCalls, 1)
+}
+
+func TestCachedScopeExpander_ExpandScopes_Empty(t *testing.T) {
+	backend := &recordingExpander{expansions: map[acl.Ownerref][]acl.Ownerref{}}
+	cached := acl.NewCachedScopeExpander(backend, 5*time.Minute)
+
+	result, err := cached.ExpandScopes(context.Background(), nil)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	assert.Empty(t, backend.scopeCalls)
+}
+
+func TestCachedScopeExpander_ExpandScopes_BackendError_Propagates(t *testing.T) {
+	backend := &recordingExpander{err: fmt.Errorf("mongo down")}
+	cached := acl.NewCachedScopeExpander(backend, 5*time.Minute)
+
+	result, err := cached.ExpandScopes(context.Background(), []acl.Ownerref{{Scope: "Project", Subject: "proj-1"}})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestCachedScopeExpander_ExpandScopes_TTLExpiry_Refetches(t *testing.T) {
+	backend := &recordingExpander{
+		expansions: map[acl.Ownerref][]acl.Ownerref{
+			{Scope: "Project", Subject: "proj-1"}: {{Scope: "KubernetesCluster", Subject: "c1"}},
+		},
+	}
+	cached := acl.NewCachedScopeExpander(backend, time.Nanosecond)
+
+	seeds := []acl.Ownerref{{Scope: "Project", Subject: "proj-1"}}
+	_, err := cached.ExpandScopes(context.Background(), seeds)
+	assert.NoError(t, err)
+	assert.Len(t, backend.scopeCalls, 1)
+
+	time.Sleep(time.Millisecond) // let the entry expire
+
+	_, err = cached.ExpandScopes(context.Background(), seeds)
+	assert.NoError(t, err)
+	assert.Len(t, backend.scopeCalls, 2) // re-fetched after expiry
+}

--- a/pkg/acl/resolver_internal_test.go
+++ b/pkg/acl/resolver_internal_test.go
@@ -1,0 +1,73 @@
+package acl
+package acl
+
+import (
+	"testing"
+
+	"github.com/NorskHelsenett/ror/pkg/models/aclmodels/aclscope"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// skipExpansion is a narrowing optimisation: it may only return true when no
+// descendant could ever pass the filter. Returning true incorrectly would drop
+// legitimately-matching descendants (too narrow); the bigger risk is that a
+// future change makes it return true when subjects are set or when the filter
+// admits other scopes, so these cases are pinned explicitly.
+func TestOwnerrefFilter_skipExpansion(t *testing.T) {
+	tests := []struct {
+		name       string
+		filter     OwnerrefFilter
+		entryScope aclscope.Scope
+		want       bool
+	}{
+		{
+			name:       "empty filter never skips (would need every descendant)",
+			filter:     OwnerrefFilter{},
+			entryScope: "KubernetesCluster",
+			want:       false,
+		},
+		{
+			name:       "single scope equal to entry, no subjects → skip",
+			filter:     OwnerrefFilter{Scopes: []aclscope.Scope{"KubernetesCluster"}},
+			entryScope: "KubernetesCluster",
+			want:       true,
+		},
+		{
+			name:       "single scope different from entry → must expand",
+			filter:     OwnerrefFilter{Scopes: []aclscope.Scope{"KubernetesCluster"}},
+			entryScope: "Project",
+			want:       false,
+		},
+		{
+			name:       "multiple scopes incl. one other than entry → must expand",
+			filter:     OwnerrefFilter{Scopes: []aclscope.Scope{"KubernetesCluster", "Project"}},
+			entryScope: "KubernetesCluster",
+			want:       false,
+		},
+		{
+			name:       "scope matches entry but subjects set → must expand",
+			filter:     OwnerrefFilter{Scopes: []aclscope.Scope{"KubernetesCluster"}, Subjects: []aclscope.Subject{"cluster-1"}},
+			entryScope: "KubernetesCluster",
+			want:       false,
+		},
+		{
+			name:       "subjects only, no scopes → must expand",
+			filter:     OwnerrefFilter{Subjects: []aclscope.Subject{"cluster-1"}},
+			entryScope: "KubernetesCluster",
+			want:       false,
+		},
+		{
+			name:       "duplicate scope equal to entry → skip",
+			filter:     OwnerrefFilter{Scopes: []aclscope.Scope{"Workspace", "Workspace"}},
+			entryScope: "Workspace",
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.filter.skipExpansion(tt.entryScope))
+		})
+	}
+}

--- a/pkg/acl/resolver_internal_test.go
+++ b/pkg/acl/resolver_internal_test.go
@@ -1,5 +1,4 @@
 package acl
-package acl
 
 import (
 	"testing"

--- a/pkg/acl/resolver_test.go
+++ b/pkg/acl/resolver_test.go
@@ -237,7 +237,7 @@ func TestResolver_ResolveOwnerrefs_Basic(t *testing.T) {
 	)
 	resolver := acl.NewResolver(store)
 
-	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"dev-team"}, "ror:read")
+	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"dev-team"}, "ror:read", acl.OwnerrefFilter{})
 	assert.NoError(t, err)
 	assert.Len(t, refs, 2)
 	assert.Contains(t, refs, acl.Ownerref{Scope: "KubernetesCluster", Subject: "cluster-1"})
@@ -255,7 +255,7 @@ func TestResolver_ResolveOwnerrefs_GlobalReturnsNil(t *testing.T) {
 	)
 	resolver := acl.NewResolver(store)
 
-	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"admins"}, "ror:read")
+	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"admins"}, "ror:read", acl.OwnerrefFilter{})
 	assert.NoError(t, err)
 	assert.Nil(t, refs) // nil = unrestricted
 }
@@ -277,7 +277,7 @@ func TestResolver_ResolveOwnerrefs_Deduplicates(t *testing.T) {
 	)
 	resolver := acl.NewResolver(store)
 
-	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"team-a", "team-b"}, "ror:read")
+	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"team-a", "team-b"}, "ror:read", acl.OwnerrefFilter{})
 	assert.NoError(t, err)
 	assert.Len(t, refs, 1) // same scope+subject, deduplicated
 }
@@ -293,7 +293,7 @@ func TestResolver_ResolveOwnerrefs_NoMatchingAccess(t *testing.T) {
 	)
 	resolver := acl.NewResolver(store)
 
-	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"dev-team"}, "ror:write")
+	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"dev-team"}, "ror:write", acl.OwnerrefFilter{})
 	assert.NoError(t, err)
 	assert.Empty(t, refs)
 	assert.NotNil(t, refs) // empty but not nil — nil means unrestricted
@@ -310,7 +310,7 @@ func TestResolver_ResolveOwnerrefs_SubjectAll(t *testing.T) {
 	)
 	resolver := acl.NewResolver(store)
 
-	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"ops"}, "ror:read")
+	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"ops"}, "ror:read", acl.OwnerrefFilter{})
 	assert.NoError(t, err)
 	assert.Nil(t, refs) // subject=all → unrestricted
 }
@@ -353,6 +353,15 @@ func (m *mockExpander) ExpandScope(_ context.Context, scope aclscope.Scope, subj
 	return m.expansions[key], nil
 }
 
+func (m *mockExpander) ExpandScopes(_ context.Context, seeds []acl.Ownerref) (map[acl.Ownerref][]acl.Ownerref, error) {
+	m.calls++
+	result := make(map[acl.Ownerref][]acl.Ownerref, len(seeds))
+	for _, seed := range seeds {
+		result[seed] = m.expansions[seed]
+	}
+	return result, nil
+}
+
 func TestResolver_ResolveOwnerrefs_WithExpander_ProjectExpands(t *testing.T) {
 	store := newMockStore(
 		aclmodels.AclV3ListItem{
@@ -373,7 +382,7 @@ func TestResolver_ResolveOwnerrefs_WithExpander_ProjectExpands(t *testing.T) {
 	}
 	resolver := acl.NewResolver(store, acl.WithScopeExpander(expander))
 
-	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"dev-team"}, "ror:read")
+	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"dev-team"}, "ror:read", acl.OwnerrefFilter{})
 	assert.NoError(t, err)
 	// Original + 3 descendants
 	assert.Len(t, refs, 4)
@@ -397,7 +406,7 @@ func TestResolver_ResolveOwnerrefs_WithExpander_LeafScope_NoExpansion(t *testing
 	}
 	resolver := acl.NewResolver(store, acl.WithScopeExpander(expander))
 
-	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"dev-team"}, "ror:read")
+	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"dev-team"}, "ror:read", acl.OwnerrefFilter{})
 	assert.NoError(t, err)
 	assert.Len(t, refs, 1)
 	assert.Contains(t, refs, acl.Ownerref{Scope: "KubernetesCluster", Subject: "cluster-1"})
@@ -429,7 +438,7 @@ func TestResolver_ResolveOwnerrefs_WithExpander_DeduplicatesAcrossEntries(t *tes
 	}
 	resolver := acl.NewResolver(store, acl.WithScopeExpander(expander))
 
-	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"dev-team"}, "ror:read")
+	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"dev-team"}, "ror:read", acl.OwnerrefFilter{})
 	assert.NoError(t, err)
 	// ws-dev + cluster-abc (deduped) + cluster-def
 	assert.Len(t, refs, 3)
@@ -447,7 +456,7 @@ func TestResolver_ResolveOwnerrefs_WithExpander_GlobalStillReturnsNil(t *testing
 	expander := &mockExpander{}
 	resolver := acl.NewResolver(store, acl.WithScopeExpander(expander))
 
-	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"admins"}, "ror:read")
+	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"admins"}, "ror:read", acl.OwnerrefFilter{})
 	assert.NoError(t, err)
 	assert.Nil(t, refs) // nil = unrestricted, expander should not be called
 	assert.Equal(t, 0, expander.calls)
@@ -465,7 +474,7 @@ func TestResolver_ResolveOwnerrefs_WithoutExpander_BackwardsCompatible(t *testin
 	// No expander — old behavior
 	resolver := acl.NewResolver(store)
 
-	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"dev-team"}, "ror:read")
+	refs, err := resolver.ResolveOwnerrefs(context.Background(), []string{"dev-team"}, "ror:read", acl.OwnerrefFilter{})
 	assert.NoError(t, err)
 	assert.Len(t, refs, 1)
 	assert.Contains(t, refs, acl.Ownerref{Scope: "Project", Subject: "proj-1"})

--- a/pkg/acl/scopeexpander.go
+++ b/pkg/acl/scopeexpander.go
@@ -23,4 +23,10 @@ import (
 // The original scope+subject is NOT included in the result.
 type ScopeExpander interface {
 	ExpandScope(ctx context.Context, scope aclscope.Scope, subject aclscope.Subject) ([]Ownerref, error)
+
+	// ExpandScopes expands several seeds in a single round-trip, returning the
+	// descendant ownerrefs for each seed keyed by the seed ownerref. It is
+	// equivalent to calling ExpandScope for each seed but avoids per-seed
+	// round-trips. Seeds with no descendants map to a nil/empty slice.
+	ExpandScopes(ctx context.Context, seeds []Ownerref) (map[Ownerref][]Ownerref, error)
 }

--- a/pkg/acl/scopeexpander_cached.go
+++ b/pkg/acl/scopeexpander_cached.go
@@ -96,8 +96,9 @@ func (c *CachedScopeExpander) ExpandScopes(ctx context.Context, seeds []Ownerref
 	}
 	c.mu.RUnlock()
 
+	uniqueSeeds := len(result)
 	span.SetAttributes(
-		attribute.Int("acl.cache_hits", len(seeds)-len(misses)),
+		attribute.Int("acl.cache_hits", uniqueSeeds-len(misses)),
 		attribute.Int("acl.cache_misses", len(misses)),
 	)
 

--- a/pkg/acl/scopeexpander_cached.go
+++ b/pkg/acl/scopeexpander_cached.go
@@ -6,6 +6,9 @@ import (
 	"time"
 
 	"github.com/NorskHelsenett/ror/pkg/models/aclmodels/aclscope"
+	"github.com/NorskHelsenett/ror/pkg/telemetry/rortracer"
+
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // CachedScopeExpander wraps a ScopeExpander with an in-memory TTL cache.
@@ -35,18 +38,27 @@ func NewCachedScopeExpander(backend ScopeExpander, ttl time.Duration) *CachedSco
 
 // ExpandScope returns cached descendants or falls through to the backend.
 func (c *CachedScopeExpander) ExpandScope(ctx context.Context, scope aclscope.Scope, subject aclscope.Subject) ([]Ownerref, error) {
+	ctx, span := rortracer.StartSpan(ctx, "acl.CachedScopeExpander.ExpandScope")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("acl.scope", string(scope)),
+		attribute.String("acl.subject", string(subject)),
+	)
+
 	key := Ownerref{Scope: scope, Subject: subject}
 
 	c.mu.RLock()
 	if entry, ok := c.cache[key]; ok && time.Now().Before(entry.expiresAt) {
 		c.mu.RUnlock()
+		span.SetAttributes(attribute.Bool("acl.cache_hit", true))
 		return entry.refs, nil
 	}
 	c.mu.RUnlock()
+	span.SetAttributes(attribute.Bool("acl.cache_hit", false))
 
 	refs, err := c.backend.ExpandScope(ctx, scope, subject)
 	if err != nil {
-		return nil, err
+		return nil, rortracer.SpanError(span, err)
 	}
 
 	c.mu.Lock()
@@ -57,6 +69,57 @@ func (c *CachedScopeExpander) ExpandScope(ctx context.Context, scope aclscope.Sc
 	c.mu.Unlock()
 
 	return refs, nil
+}
+
+// ExpandScopes expands several seeds, serving each from the in-memory cache when
+// possible and resolving all cache misses through the backend in a single batched
+// call. Results are keyed by seed ownerref.
+func (c *CachedScopeExpander) ExpandScopes(ctx context.Context, seeds []Ownerref) (map[Ownerref][]Ownerref, error) {
+	ctx, span := rortracer.StartSpan(ctx, "acl.CachedScopeExpander.ExpandScopes")
+	defer span.End()
+	span.SetAttributes(attribute.Int("acl.seeds", len(seeds)))
+
+	result := make(map[Ownerref][]Ownerref, len(seeds))
+	var misses []Ownerref
+
+	c.mu.RLock()
+	for _, seed := range seeds {
+		if _, done := result[seed]; done {
+			continue
+		}
+		if entry, ok := c.cache[seed]; ok && time.Now().Before(entry.expiresAt) {
+			result[seed] = entry.refs
+		} else {
+			result[seed] = nil
+			misses = append(misses, seed)
+		}
+	}
+	c.mu.RUnlock()
+
+	span.SetAttributes(
+		attribute.Int("acl.cache_hits", len(seeds)-len(misses)),
+		attribute.Int("acl.cache_misses", len(misses)),
+	)
+
+	if len(misses) == 0 {
+		return result, nil
+	}
+
+	expanded, err := c.backend.ExpandScopes(ctx, misses)
+	if err != nil {
+		return nil, rortracer.SpanError(span, err)
+	}
+
+	now := time.Now()
+	c.mu.Lock()
+	for _, seed := range misses {
+		refs := expanded[seed]
+		c.cache[seed] = cachedExpansion{refs: refs, expiresAt: now.Add(c.ttl)}
+		result[seed] = refs
+	}
+	c.mu.Unlock()
+
+	return result, nil
 }
 
 // Invalidate removes the cached expansion for a specific scope+subject.

--- a/pkg/clients/rorclient/client.go
+++ b/pkg/clients/rorclient/client.go
@@ -18,6 +18,7 @@ import (
 	v1token "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v1/token"
 	"github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v1/v1clientset"
 	v1workspaces "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v1/workspaces"
+	v2acl "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v2/acl"
 	v2apikeys "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v2/apikeys"
 	v2resources "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v2/resources"
 	"github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v2/rorclientv2self"
@@ -65,6 +66,7 @@ type RorClient struct {
 	resourcesClientV2  v2resources.ResourcesInterface
 	streamClientV2     v2stream.StreamInterface
 	aclClientV1        v1acl.AclInterface
+	aclClientV2        v2acl.AclInterface
 	tokenClientV1      v1token.TokenInterface
 	tokenClientV2      v2token.TokenInterface
 	v1                 clientinterface.RorCommonClientApiInterfaceV1
@@ -75,6 +77,7 @@ func NewRorClient(transport transportinterface.RorTransport) *RorClient {
 	return &RorClient{
 		Transport:          transport,
 		aclClientV1:        transport.Acl(),
+		aclClientV2:        transport.AclV2(),
 		streamClientV1:     transport.Stream(),
 		infoClientV1:       transport.Info(),
 		datacenterClientV1: transport.Datacenters(),
@@ -109,6 +112,9 @@ func (c *RorClient) Acl() v1acl.AclInterface {
 	return c.aclClientV1
 }
 
+func (c *RorClient) AclV2() v2acl.AclInterface {
+	return c.aclClientV2
+}
 func (c *RorClient) Info() v1info.InfoInterface {
 	return c.infoClientV1
 }

--- a/pkg/clients/rorclient/transports/resttransport/transport.go
+++ b/pkg/clients/rorclient/transports/resttransport/transport.go
@@ -20,6 +20,7 @@ import (
 	v1stream "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v1/stream"
 	v1token "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v1/token"
 	v1workspaces "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v1/workspaces"
+	v2acl "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v2/acl"
 	v2apikeys "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v2/apikeys"
 	v2resources "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v2/resources"
 	v2self "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v2/rorclientv2self"
@@ -35,6 +36,7 @@ import (
 	restv1token "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/transports/resttransport/v1/token"
 	restv1stream "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/transports/resttransport/v1/v1stream"
 	restv1workspaces "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/transports/resttransport/v1/workspaces"
+	restv2acl "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/transports/resttransport/v2/acl"
 	restv2apikeys "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/transports/resttransport/v2/apikeys"
 	restv2resources "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/transports/resttransport/v2/resources"
 	"github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/transports/resttransport/v2/restclientv2self"
@@ -59,6 +61,7 @@ type RorHttpTransport struct {
 	metricsClientV1    v1metrics.MetricsInterface
 	resourcesClientV2  v2resources.ResourcesInterface
 	aclClientV1        v1Acl.AclInterface
+	aclClientV2        v2acl.AclInterface
 	selfClientV2       v2self.SelfInterface
 	streamClientV2     v2stream.StreamInterface
 	tokenClientV1      v1token.TokenInterface
@@ -92,6 +95,7 @@ func newWithHttpClient(config *httpclient.HttpTransportClientConfig, httpClient 
 		resourcesClientV2:  restv2resources.NewV2Client(client),
 		streamClientV2:     restv2stream.NewV2Client(v2sseclient.NewSSEClient(client)),
 		aclClientV1:        restv1Acl.NewV1Client(client),
+		aclClientV2:        restv2acl.NewV2Client(client),
 		tokenClientV1:      restv1token.NewV1Client(client),
 		tokenClientV2:      restv2token.NewV2Client(client),
 	}
@@ -146,6 +150,10 @@ func (t *RorHttpTransport) ResourcesV2() v2resources.ResourcesInterface {
 
 func (t *RorHttpTransport) AclV1() v1Acl.AclInterface {
 	return t.aclClientV1
+}
+
+func (t *RorHttpTransport) AclV2() v2acl.AclInterface {
+	return t.aclClientV2
 }
 
 func (t *RorHttpTransport) Token() v1token.TokenInterface {

--- a/pkg/clients/rorclient/v2/interfaces/clientinterface/client.go
+++ b/pkg/clients/rorclient/v2/interfaces/clientinterface/client.go
@@ -11,6 +11,7 @@ import (
 	v1stream "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v1/stream"
 	v1token "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v1/token"
 	v1workspaces "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v1/workspaces"
+	v2acl "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v2/acl"
 	v2apikeys "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v2/apikeys"
 	v2resources "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v2/resources"
 	"github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v2/rorclientv2self"
@@ -21,6 +22,7 @@ import (
 
 type RorCommonClientApiInterface interface {
 	Acl() v1acl.AclInterface
+	AclV2() v2acl.AclInterface
 	ApiKeysV2() v2apikeys.ApiKeysInterface
 	Clusters() v1clusters.ClustersInterface
 	Datacenters() v1datacenter.DatacenterInterface
@@ -56,6 +58,7 @@ type RorCommonClientApiInterfaceV1 interface {
 }
 
 type RorCommonClientApiInterfaceV2 interface {
+	Acl() v2acl.AclInterface
 	ApiKeys() v2apikeys.ApiKeysInterface
 	Resources() v2resources.ResourcesInterface
 	Stream() v2stream.StreamInterface

--- a/pkg/clients/rorclient/v2/interfaces/v2/acl/acl.go
+++ b/pkg/clients/rorclient/v2/interfaces/v2/acl/acl.go
@@ -1,0 +1,15 @@
+package acl
+
+import (
+	"context"
+
+	"github.com/NorskHelsenett/ror/pkg/models/aclmodels"
+)
+
+type AclInterface interface {
+	// Lookup resolves the scope+subject pairs the caller has the given access
+	// type for, using the V3 ACL backend. The optional scopes and subjects
+	// narrow the result to the given scopes and/or subjects (uids); pass nil for
+	// no filtering.
+	Lookup(ctx context.Context, access string, scopes []string, subjects []string) (*aclmodels.AclV3LookupResponse, error)
+}

--- a/pkg/clients/rorclient/v2/interfaces/v2/v2clientset/v2.go
+++ b/pkg/clients/rorclient/v2/interfaces/v2/v2clientset/v2.go
@@ -32,9 +32,11 @@ func NewV2ClientSet(transport transportinterface.RorTransport) clientinterface.R
 		tokenClientV2:     transport.TokenV2(),
 	}
 }
+
 func (c *ClientSet) Acl() acl.AclInterface {
 	return c.aclClientV2
 }
+
 func (c *ClientSet) ApiKeys() apikeys.ApiKeysInterface {
 	return c.apikeysClientV2
 }

--- a/pkg/clients/rorclient/v2/interfaces/v2/v2clientset/v2.go
+++ b/pkg/clients/rorclient/v2/interfaces/v2/v2clientset/v2.go
@@ -3,6 +3,7 @@ package v2clientset
 import (
 	"github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/clientinterface"
 	"github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/transports/transportinterface"
+	"github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v2/acl"
 	"github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v2/apikeys"
 	"github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v2/resources"
 	"github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v2/rorclientv2self"
@@ -13,6 +14,7 @@ import (
 type ClientSet struct {
 	transport transportinterface.RorTransport
 
+	aclClientV2       acl.AclInterface
 	apikeysClientV2   apikeys.ApiKeysInterface
 	selfClientV2      rorclientv2self.SelfInterface
 	resourcesClientV2 resources.ResourcesInterface
@@ -22,12 +24,16 @@ type ClientSet struct {
 
 func NewV2ClientSet(transport transportinterface.RorTransport) clientinterface.RorCommonClientApiInterfaceV2 {
 	return &ClientSet{
+		aclClientV2:       transport.AclV2(),
 		apikeysClientV2:   transport.ApiKeysV2(),
 		selfClientV2:      transport.Self(),
 		resourcesClientV2: transport.ResourcesV2(),
 		streamClientV2:    transport.StreamV2(),
 		tokenClientV2:     transport.TokenV2(),
 	}
+}
+func (c *ClientSet) Acl() acl.AclInterface {
+	return c.aclClientV2
 }
 func (c *ClientSet) ApiKeys() apikeys.ApiKeysInterface {
 	return c.apikeysClientV2

--- a/pkg/clients/rorclient/v2/transports/resttransport/transport.go
+++ b/pkg/clients/rorclient/v2/transports/resttransport/transport.go
@@ -20,6 +20,7 @@ import (
 	v1stream "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v1/stream"
 	v1token "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v1/token"
 	v1workspaces "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v1/workspaces"
+	v2acl "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v2/acl"
 	v2apikeys "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v2/apikeys"
 	v2resources "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v2/resources"
 	v2self "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/interfaces/v2/rorclientv2self"
@@ -35,6 +36,7 @@ import (
 	restv1token "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/transports/resttransport/v1/token"
 	restv1stream "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/transports/resttransport/v1/v1stream"
 	restv1workspaces "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/transports/resttransport/v1/workspaces"
+	restv2acl "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/transports/resttransport/v2/acl"
 	restv2apikeys "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/transports/resttransport/v2/apikeys"
 	restv2resources "github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/transports/resttransport/v2/resources"
 	"github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/transports/resttransport/v2/restclientv2self"
@@ -59,6 +61,7 @@ type RorHttpTransport struct {
 	metricsClientV1    v1metrics.MetricsInterface
 	resourcesClientV2  v2resources.ResourcesInterface
 	aclClientV1        v1Acl.AclInterface
+	aclClientV2        v2acl.AclInterface
 	selfClientV2       v2self.SelfInterface
 	streamClientV2     v2stream.StreamInterface
 	tokenClientV1      v1token.TokenInterface
@@ -92,6 +95,7 @@ func newWithHttpClient(config *httpclient.HttpTransportClientConfig, httpClient 
 		resourcesClientV2:  restv2resources.NewV2Client(client),
 		streamClientV2:     restv2stream.NewV2Client(v2sseclient.NewSSEClient(client)),
 		aclClientV1:        restv1Acl.NewV1Client(client),
+		aclClientV2:        restv2acl.NewV2Client(client),
 		tokenClientV1:      restv1token.NewV1Client(client),
 		tokenClientV2:      restv2token.NewV2Client(client),
 	}
@@ -146,6 +150,10 @@ func (t *RorHttpTransport) ResourcesV2() v2resources.ResourcesInterface {
 
 func (t *RorHttpTransport) AclV1() v1Acl.AclInterface {
 	return t.aclClientV1
+}
+
+func (t *RorHttpTransport) AclV2() v2acl.AclInterface {
+	return t.aclClientV2
 }
 
 func (t *RorHttpTransport) Token() v1token.TokenInterface {

--- a/pkg/clients/rorclient/v2/transports/resttransport/v2/acl/acl.go
+++ b/pkg/clients/rorclient/v2/transports/resttransport/v2/acl/acl.go
@@ -1,0 +1,53 @@
+package acl
+
+import (
+	"context"
+	"net/url"
+	"strings"
+
+	"github.com/NorskHelsenett/ror/pkg/clients/rorclient/v2/transports/resttransport/httpclient"
+	"github.com/NorskHelsenett/ror/pkg/models/aclmodels"
+)
+
+type V2Client struct {
+	Client   *httpclient.HttpTransportClient
+	BasePath string
+}
+
+func NewV2Client(client *httpclient.HttpTransportClient) *V2Client {
+	return &V2Client{
+		Client:   client,
+		BasePath: "/v2/acl",
+	}
+}
+
+func (c V2Client) Lookup(ctx context.Context, access string, scopes []string, subjects []string) (*aclmodels.AclV3LookupResponse, error) {
+	u, err := url.Parse(c.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	u = u.JoinPath("lookup")
+
+	query := make(map[string]string)
+	if access != "" {
+		query["access"] = access
+	}
+	if len(scopes) > 0 {
+		query["scope"] = strings.Join(scopes, ",")
+	}
+	if len(subjects) > 0 {
+		query["subject"] = strings.Join(subjects, ",")
+	}
+
+	var res aclmodels.AclV3LookupResponse
+	err = c.Client.GetJSON(ctx, u.String(), &res, httpclient.HttpTransportClientParams{
+		Key:   httpclient.HttpTransportClientOptsQuery,
+		Value: query,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}

--- a/pkg/config/rorconfig/rorconsts.go
+++ b/pkg/config/rorconfig/rorconsts.go
@@ -60,6 +60,9 @@ const (
 	// KV_VAULT_ROLE is the vault database role used to issue redis/valkey
 	// credentials. When empty it defaults to "valkey-<ROLE>-role".
 	KV_VAULT_ROLE ConfigConst = "KV_VAULT_ROLE"
+	// KV_ENABLED gates whether the redis/valkey client is initialized. It is
+	// enabled by default; set it to "false" to skip connecting to redis.
+	KV_ENABLED ConfigConst = "KV_ENABLED"
 
 	TRACER_ID                        ConfigConst = "TRACER_ID"
 	ENABLE_TRACING                   ConfigConst = "ENABLE_TRACING"
@@ -129,6 +132,7 @@ var ConfigConsts = EnvironmentVariables{
 	{key: "KV_HOST", deprecated: false, description: ""},
 	{key: "KV_PORT", deprecated: false, description: ""},
 	{key: "KV_VAULT_ROLE", deprecated: false, description: ""},
+	{key: "KV_ENABLED", deprecated: false, description: "Enables the redis/valkey client. Enabled by default; set to false to disable."},
 	{key: "TRACER_ID", deprecated: false, description: ""},
 	{key: "ENABLE_TRACING", deprecated: false, description: ""},
 	{key: "OPENTELEMETRY_COLLECTOR_ENDPOINT", deprecated: false, description: ""},

--- a/pkg/models/aclmodels/aclModelsV3Lookup.go
+++ b/pkg/models/aclmodels/aclModelsV3Lookup.go
@@ -1,0 +1,19 @@
+package aclmodels
+
+import "github.com/NorskHelsenett/ror/pkg/models/aclmodels/aclscope"
+
+// AclV3LookupOwnerref is a single scope+subject pair the caller has access to.
+type AclV3LookupOwnerref struct {
+	Scope   aclscope.Scope   `json:"scope"`
+	Subject aclscope.Subject `json:"subject"`
+}
+
+// AclV3LookupResponse is the response for GET /v2/acl/lookup. It lists the
+// scope+subject pairs the caller has the requested access type for, resolved
+// through the V3 ACL backend. When Unrestricted is true the caller has global
+// access for the requested access type and Ownerrefs is empty.
+type AclV3LookupResponse struct {
+	Access       AccessTypeV3          `json:"access"`
+	Unrestricted bool                  `json:"unrestricted"`
+	Ownerrefs    []AclV3LookupOwnerref `json:"ownerrefs"`
+}


### PR DESCRIPTION
- Introduced a new V2 ACL client interface and implementation for handling access control lookups.
- Updated existing resolver tests to accommodate the new OwnerrefFilter parameter in ResolveOwnerrefs method.
- Implemented caching for scope expansions in CachedScopeExpander, optimizing performance for multiple seed expansions.
- Added telemetry tracing for cache hits and misses in the CachedScopeExpander.
- Enhanced the configuration constants to include KV_ENABLED for controlling Redis client initialization.
- Created new models for ACL V3 lookup responses to standardize data handling.
- Added unit tests for OwnerrefFilter skipExpansion logic to ensure correct filtering behavior.